### PR TITLE
MDLSITE-2094: Look for some more strings on phpunit output

### DIFF
--- a/run_phpunittests/run_phpunittests.sh
+++ b/run_phpunittests/run_phpunittests.sh
@@ -97,6 +97,41 @@ if [ $exitstatus -eq 0 ]; then
     fi
 fi
 
+# MDLSITE-1972. Verify that all the test directories in codebase
+# are matched/covered by the definitions in the generated phpunit.xml.
+# Any error will stop execution and fail the job.
+
+# Load all the defined tests
+definedtests=$(grep -r "directory suffix" ${gitdir}/phpunit.xml | sed 's/^[^>]*>\([^<]*\)<.*$/\1/g')
+# Load all the existing tests
+existingtests=$(cd ${gitdir} && find . -name tests | sed 's/^\.\/\(.*\)$/\1/g')
+# Some well-known "tests" that we can ignore here
+ignoretests="local/codechecker/pear/PHP/tests lib/phpexcel/PHPExcel/Shared/JAMA/tests"
+# Verify that each existing test is covered by some defined test
+for existing in ${existingtests}
+do
+    found=""
+    # Skip any existing test defined as ignoretests
+    if [[ ${ignoretests} =~ ${existing} ]]; then
+        echo "NOTE: Ignoring ${existing}, not part of core."
+        continue
+    fi
+    for defined in ${definedtests}
+    do
+        if [[ ${existing} =~ ^${defined}$ ]]; then
+            echo "OK: ${existing} will be executed because there is a matching definition for it."
+            found="1"
+        elif [[ ${existing} =~ ^${defined}/.* ]]; then
+            echo "NOTE: ${existing} will be executed because the ${defined} definition covers it."
+            found="1"
+        fi
+    done
+    if [[ -z ${found} ]]; then
+        echo "ERROR: ${existing} is not matched/covered by any definition in phpunit.xml !"
+        exitstatus=1
+    fi
+done
+
 # Execute the phpunit utility
 # Conditionally
 if [ $exitstatus -eq 0 ]; then


### PR DESCRIPTION
Link: https://tracker.moodle.org/browse/MDLSITE-2094

We were already looking for some PHP stack traces to detect any problem when running unit tests. But that was not enough to get debugging and/or other stack traces.

So the patch introduces two more searches within the output of phpunit tests to detect any "Debugging:" output and also any general backtrace information ("line XX of XXXX: call to").

Seems to be working here. Ciao :-)
