### PR TITLE
MDL-35332 - exclude lib/password_compat/ from checks

### DIFF
--- a/define_excluded/define_excluded.sh
+++ b/define_excluded/define_excluded.sh
@@ -24,6 +24,7 @@ lib/htmlpurifier/
 lib/jabber/
 lib/minify/
 lib/overlib/
+lib/password_compat/
 lib/pear/
 lib/phpexcel/
 lib/phpmailer/


### PR DESCRIPTION
Its a third party library and so should be excluded.
