### PR TITLE
MDLSITE-2184 ci: reset caches to get fresh list of components

### DIFF
--- a/list_valid_components/list_valid_components.php
+++ b/list_valid_components/list_valid_components.php
@@ -90,6 +90,13 @@ if (!is_bool($options['absolute'])) {
     cli_error('Incorrect absolute value, bool expected: ' . $options['absolute']);
 }
 
+// Purge all caches, we don't want anything but fresh results. MDLSITE-2184.
+// TODO: Alternatively, we should be creating a new site to make this work
+// without the moodle_ci_site requirement and the fake dirroot.
+if (function_exists('purge_all_caches')) {
+        purge_all_caches();
+}
+
 // Let's fake dirroot to look in the correct directory
 global $CFG;
 $olddirroot = $CFG->dirroot;


### PR DESCRIPTION
Ensure everything is reset (using high level call). And forget. Will cause a minimal slowdown of the ci_site... but it's not really used much.
