### PR TITLE
MDLSITE-2100 ci: never reset to origin, can contain newer commits

### DIFF
--- a/check_upgrade_savepoints/check_upgrade_savepoints.sh
+++ b/check_upgrade_savepoints/check_upgrade_savepoints.sh
@@ -14,7 +14,7 @@ echo -n > "$resultfile"
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # checkout pristine copy of the configure branch
-cd $gitdir && git checkout $gitbranch && git reset --hard origin/$gitbranch
+cd $gitdir && git reset --hard $gitbranch
 
 # copy the checker to the gitdir
 cp $mydir/check_upgrade_savepoints.php $gitdir/

--- a/compare_databases/compare_databases.sh
+++ b/compare_databases/compare_databases.sh
@@ -61,7 +61,7 @@ if [ $exitstatus -ne 0 ]; then
 fi
 
 # Do the moodle install of $installdb
-cd $gitdir && git checkout $gitbranchinstalled && git reset --hard origin/$gitbranchinstalled
+cd $gitdir && git reset --hard $gitbranchinstalled
 rm -fr config.php
 ${phpcmd} admin/cli/install.php --non-interactive --allow-unstable --agree-license --wwwroot="http://localhost" --dataroot="$datadir" --dbtype=$dbtype --dbhost=$dbhost1 --dbname=$installdb --dbuser=$dbuser1 --dbpass=$dbpass1 --prefix=$dbprefixinstall --fullname=$installdb --shortname=$installdb --adminuser=$dbuser1 --adminpass=$dbpass1
 # Error installing, we cannot continue. Exit
@@ -75,7 +75,8 @@ fi
 # Do the moodle install of $upgradedb
 # only if we don't come from an erroneus previous situation
 if [ $exitstatus -eq 0 ]; then
-    cd $gitdir && git checkout $gitbranchupgraded && git reset --hard origin/$gitbranchupgraded
+    # Detached head, good enough
+    cd $gitdir && git checkout origin/$gitbranchupgraded
     rm -fr config.php
     ${phpcmd} admin/cli/install.php --non-interactive --allow-unstable --agree-license --wwwroot="http://localhost" --dataroot="$datadir" --dbtype=$dbtype --dbhost=$dbhost2 --dbname=$upgradedb --dbuser=$dbuser2 --dbpass=$dbpass2 --prefix=$dbprefixupgrade --fullname=$upgradedb --shortname=$upgradedb --adminuser=$dbuser2 --adminpass=$dbpass2
     # Error installing, we cannot continue. Exit
@@ -88,7 +89,7 @@ fi
 # Do the moodle upgrade
 # only if we don't come from an erroneus previous situation
 if [ $exitstatus -eq 0 ]; then
-    cd $gitdir && git checkout $gitbranchinstalled && git reset --hard origin/$gitbranchinstalled
+    cd $gitdir && git reset --hard $gitbranchinstalled
     ${phpcmd} admin/cli/upgrade.php --non-interactive --allow-unstable
     # Error upgrading, inform and continue
     exitstatus=${PIPESTATUS[0]}

--- a/detect_conflicts/detect_conflicts.sh
+++ b/detect_conflicts/detect_conflicts.sh
@@ -16,7 +16,7 @@ countfile=$WORKSPACE/detect_conflicts_counters_$gitbranch.csv
 mincountfile=$WORKSPACE/detect_conflicts_mincounter_$gitbranch.csv
 
 # Co to proper gitdir and gitpath
-cd $gitdir && git checkout $gitbranch && git reset --hard origin/$gitbranch
+cd $gitdir && git reset --hard $gitbranch
 
 # Search and send to $lastfile
 echo -n > "$lastfile"

--- a/illegal_whitespace/illegal_whitespace.sh
+++ b/illegal_whitespace/illegal_whitespace.sh
@@ -16,7 +16,7 @@ countfile=$WORKSPACE/illegal_whitespace_counters_$gitbranch.csv
 mincountfile=$WORKSPACE/illegal_whitespace_mincounter_$gitbranch.csv
 
 # Co to proper gitdir and gitpath
-cd $gitdir && git checkout $gitbranch && git reset --hard origin/$gitbranch
+cd $gitdir && git reset --hard $gitbranch
 
 # Search and send to $lastfile
 echo -n > "$lastfile"

--- a/run_phpunittests/run_phpunittests.sh
+++ b/run_phpunittests/run_phpunittests.sh
@@ -52,7 +52,7 @@ if [ $exitstatus -ne 0 ]; then
 fi
 
 # Do the moodle install
-cd $gitdir && git checkout $gitbranch && git reset --hard origin/$gitbranch
+cd $gitdir && git reset --hard $gitbranch
 rm -fr config.php
 rm -fr ${resultfile}
 

--- a/run_simpletests/run_simpletests.sh
+++ b/run_simpletests/run_simpletests.sh
@@ -34,7 +34,7 @@ if [ $exitstatus -ne 0 ]; then
 fi
 
 # Do the moodle install
-cd $gitdir && git checkout $gitbranch && git reset --hard origin/$gitbranch
+cd $gitdir && git reset --hard $gitbranch
 rm -fr config.php
 ${phpcmd} admin/cli/install.php --non-interactive --allow-unstable --agree-license --wwwroot="http://localhost" --dataroot="$datadir" --dbtype=$dbtype --dbhost=$dbhost --dbname=$installdb --dbuser=$dbuser --dbpass=$dbpass --prefix=$dbprefixinstall --fullname=$installdb --shortname=$installdb --adminuser=$dbuser --adminpass=$dbpass
 # Error installing, we cannot continue.

--- a/shifter_walk/shifter_walk.sh
+++ b/shifter_walk/shifter_walk.sh
@@ -21,7 +21,7 @@ outputfile=${WORKSPACE}/shifter_walk.txt
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Ensure git is ready
-cd ${gitdir} && git checkout ${gitbranch} && git reset --hard origin/${gitbranch}
+cd ${gitdir} && git reset --hard ${gitbranch}
 rm -fr config.php
 rm -fr ${outputfile}
 


### PR DESCRIPTION
All the jobs that are chained per branch cannot be reset to
their origin/xxxx counterpart because it's possible that the
git poll already had incorporated commits for the next run. So
the reset is performed to local branch and done.

Note that the git poll itself is configured to renew the local
branches once the next run starts (not before, poll knows that
it has to wait until the whole chain ends before renewing local
branches).
