### PR TITLE
NOBUG: Delete all shifted files before running shifter

### DIFF
--- a/shifter_walk/shifter_walk.sh
+++ b/shifter_walk/shifter_walk.sh
@@ -55,6 +55,9 @@ fi
 
 # Run shifter against the git repo
 cd ${gitdir}
+# First delete all shifted files so we can detect stale files in the build dir
+rm -fr `find . -path '*/yui/build' -type d`
+
 ${shifterbase}/${shifterversion}/node_modules/shifter/bin/shifter --walk --recursive | tee "${outputfile}"
 exitstatus=${PIPESTATUS[0]}
 if [ $exitstatus -ne 0 ]; then


### PR DESCRIPTION
This will let us detect stale files sitting in the build dir.
Handily - there are some there already that can be used to check this patch.
