### PR TITLE
MDLSITE-2623 Improve the components list for >=2.6

### DIFF
--- a/list_valid_components/clilib.php
+++ b/list_valid_components/clilib.php
@@ -1,0 +1,177 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Command line utility functions and classes
+ *
+ * @package    core
+ * @subpackage cli
+ * @copyright  2009 Petr Skoda (http://skodak.org)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+// NOTE: no MOODLE_INTERNAL test here, sometimes we use this before requiring Moodle libs!
+
+/**
+ * Get input from user
+ * @param string $prompt text prompt, should include possible options
+ * @param string $default default value when enter pressed
+ * @param array $options list of allowed options, empty means any text
+ * @param bool $casesensitive true if options are case sensitive
+ * @return string entered text
+ */
+function cli_input($prompt, $default='', array $options=null, $casesensitiveoptions=false) {
+    echo $prompt;
+    echo "\n: ";
+    $input = fread(STDIN, 2048);
+    $input = trim($input);
+    if ($input === '') {
+        $input = $default;
+    }
+    if ($options) {
+        if (!$casesensitiveoptions) {
+            $input = strtolower($input);
+        }
+        if (!in_array($input, $options)) {
+            echo "Incorrect value, please retry.\n"; // TODO: localize, mark as needed in install
+            return cli_input($prompt, $default, $options, $casesensitiveoptions);
+        }
+    }
+    return $input;
+}
+
+/**
+ * Returns cli script parameters.
+ * @param array $longoptions array of --style options ex:('verbose'=>false)
+ * @param array $shortmapping array describing mapping of short to long style options ex:('h'=>'help', 'v'=>'verbose')
+ * @return array array of arrays, options, unrecognised as optionlongname=>value
+ */
+function cli_get_params(array $longoptions, array $shortmapping=null) {
+    $shortmapping = (array)$shortmapping;
+    $options      = array();
+    $unrecognized = array();
+
+    if (empty($_SERVER['argv'])) {
+        // bad luck, we can continue in interactive mode ;-)
+        return array($options, $unrecognized);
+    }
+    $rawoptions = $_SERVER['argv'];
+
+    //remove anything after '--', options can not be there
+    if (($key = array_search('--', $rawoptions)) !== false) {
+        $rawoptions = array_slice($rawoptions, 0, $key);
+    }
+
+    //remove script
+    unset($rawoptions[0]);
+    foreach ($rawoptions as $raw) {
+        if (substr($raw, 0, 2) === '--') {
+            $value = substr($raw, 2);
+            $parts = explode('=', $value);
+            if (count($parts) == 1) {
+                $key   = reset($parts);
+                $value = true;
+            } else {
+                $key = array_shift($parts);
+                $value = implode('=', $parts);
+            }
+            if (array_key_exists($key, $longoptions)) {
+                $options[$key] = $value;
+            } else {
+                $unrecognized[] = $raw;
+            }
+
+        } else if (substr($raw, 0, 1) === '-') {
+            $value = substr($raw, 1);
+            $parts = explode('=', $value);
+            if (count($parts) == 1) {
+                $key   = reset($parts);
+                $value = true;
+            } else {
+                $key = array_shift($parts);
+                $value = implode('=', $parts);
+            }
+            if (array_key_exists($key, $shortmapping)) {
+                $options[$shortmapping[$key]] = $value;
+            } else {
+                $unrecognized[] = $raw;
+            }
+        } else {
+            $unrecognized[] = $raw;
+            continue;
+        }
+    }
+    //apply defaults
+    foreach ($longoptions as $key=>$default) {
+        if (!array_key_exists($key, $options)) {
+            $options[$key] = $default;
+        }
+    }
+    // finished
+    return array($options, $unrecognized);
+}
+
+/**
+ * Print or return section separator string
+ * @param bool $return false means print, true return as string
+ * @return mixed void or string
+ */
+function cli_separator($return=false) {
+    $separator = str_repeat('-', 79)."\n";
+    if ($return) {
+        return $separator;
+    } else {
+        echo $separator;
+    }
+}
+
+/**
+ * Print or return section heading string
+ * @param string $string text
+ * @param bool $return false means print, true return as string
+ * @return mixed void or string
+ */
+function cli_heading($string, $return=false) {
+    $string = "== $string ==\n";
+    if ($return) {
+        return $string;
+    } else {
+        echo $string;
+    }
+}
+
+/**
+ * Write error notification
+ * @param $text
+ * @return void
+ */
+function cli_problem($text) {
+    fwrite(STDERR, $text."\n");
+}
+
+/**
+ * Write to standard out and error with exit in error.
+ *
+ * @param string $text
+ * @param int $errorcode
+ * @return void (does not return)
+ */
+function cli_error($text, $errorcode=1) {
+    fwrite(STDERR, $text);
+    fwrite(STDERR, "\n");
+    die($errorcode);
+}

--- a/list_valid_components/list_valid_components.sh
+++ b/list_valid_components/list_valid_components.sh
@@ -22,6 +22,22 @@ done
 
 # calculate some variables
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Since Moodle 2.6 we don't need to install the moodle site nor copy the php script to it.
+if [[ -f "${gitdir}/lib/classes/component.php" ]]; then
+    cd ${mydir}
+    ${phpcmd} list_valid_components.php --basedir="${gitdir}" --absolute=true
+    exitstatus=${PIPESTATUS[0]}
+    if [ $exitstatus -ne 0 ]; then
+        echo "Problem executing the >= 2.6 alternative"
+    fi
+    # Done, it was easy and cheap!
+    exit $exitstatus
+fi
+
+# Up to Moodle 2.5 we need to install a complete site and copy the script to local/ci/list_valid_components
+# to get a reliable list of components.
+
 installdb=ci_installed_${BUILD_NUMBER}_${EXECUTOR_NUMBER}
 datadir=/tmp/ci_dataroot_${BUILD_NUMBER}_${EXECUTOR_NUMBER}
 dbprefixinstall="cii_"
@@ -51,7 +67,7 @@ fi
 # only if we don't come from an erroneus previous situation
 if [ $exitstatus -eq 0 ]; then
     mkdir -p ${gitdir}/local/ci/list_valid_components
-    cp ${mydir}/list_valid_components.php ${gitdir}/local/ci/list_valid_components
+    cp ${mydir}/*.php ${gitdir}/local/ci/list_valid_components
     ${phpcmd} ${gitdir}/local/ci/list_valid_components/list_valid_components.php \
         --basedir="${gitdir}" --absolute=true
 fi

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -143,13 +143,11 @@ set +e
 #    type (plugin, subsystem)
 #    name (frankestyle component name)
 #    path (full or null)
-# Here we are using the list of components valid for the moodle-ci site, not the
-# components of the branch being checked. We may change to the later, but that would
-# imply installing the site all over the time and ususally we don't drop plugins but add
-# new ones, so master should be ok 99.99% of times.
-# If, not, just change the call to the  shell script instead of the php script
-# and add the required (dbxxxx) variables to the job.
-# Note that will cause every execution to spend > 1 minute installing.
+# For 2.6 and upwards the list of components is calculated for the branch
+# being checked (100% correct behavior). For previous branches we are using
+# the list of components available in the moodle-ci-site, because getting
+# the list from the checkd branch does require installing the site completely and
+# that would slowdown the checker a lot. It's ok 99% of times.
 ${phpcmd} ${mydir}/../list_valid_components/list_valid_components.php \
     --basedir="${WORKSPACE}" --absolute=true > "${WORKSPACE}/work/valid_components.txt"
 


### PR DESCRIPTION
Since 2.6 we can use the core_component class plain and straight
without requiring a complete site to be installed. Let's use it,
that will save some precious minutes on each iteration. Also will
benefit the prechecker (previously always using the moodle-ci-site
list of components).
