### PR TITLE
Added lib/lessphp to the list of excluded dirs

### DIFF
--- a/define_excluded/define_excluded.sh
+++ b/define_excluded/define_excluded.sh
@@ -26,6 +26,7 @@ lib/google/
 lib/htmlpurifier/
 lib/jabber/
 lib/jquery/
+lib/lessphp/
 lib/minify/
 lib/overlib/
 lib/password_compat/


### PR DESCRIPTION
Hi guys,

https://tracker.moodle.org/browse/MDL-44357 has been integrated which added a new 3rd party lib lessphp (https://github.com/oyejorge/less.php) to Moodle.
This commit simply adds it to the list of directories to exclude as it breaks our whitespace count.

Cheers
Sam
