### PR TITLE
NOBUG: Simple cleanup

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -166,19 +166,6 @@ $( grep '<file name=' ${WORKSPACE}/work/patchset.xml | \
 sed '/^$/d' ${WORKSPACE}/work/patchset.files >  ${WORKSPACE}/work/patchset.files.tmp
 mv ${WORKSPACE}/work/patchset.files.tmp ${WORKSPACE}/work/patchset.files
 
-# ########## ########## ########## ##########
-
-# Disable exit-on-error for the rest of the script, it will
-# advance no matter of any check returning error. At the end
-# we will decide based on gathered information
-set +e
-
-# First, we execute all the checks requiring complete site codebase
-
-# Run the PHPCPD (commented out 20120823 Eloy)
-#${phpcmd} ${mydir}/../copy_paste_detector/copy_paste_detector.php \
-#    ${excluded_list} --quiet --log-pmd "${WORKSPACE}/work/cpd.xml" ${WORKSPACE}
-
 # Before deleting all the files not part of the patchest we calculate the
 # complete list of valid components (plugins, subplugins and subsystems)
 # so later various utilities can use it for their own checks/reports.
@@ -194,6 +181,19 @@ set +e
 ${phpcmd} ${mydir}/../list_valid_components/list_valid_components.php \
     --basedir="${WORKSPACE}" --absolute=true > "${WORKSPACE}/work/valid_components.txt"
 
+# ########## ########## ########## ##########
+
+# Disable exit-on-error for the rest of the script, it will
+# advance no matter of any check returning error. At the end
+# we will decide based on gathered information
+set +e
+
+# First, we execute all the checks requiring complete site codebase
+
+# Run the PHPCPD (commented out 20120823 Eloy)
+#${phpcmd} ${mydir}/../copy_paste_detector/copy_paste_detector.php \
+#    ${excluded_list} --quiet --log-pmd "${WORKSPACE}/work/cpd.xml" ${WORKSPACE}
+
 # TODO: Run the db install/upgrade comparison check
 # (only if there is any *install* or *upgrade* file involved)
 
@@ -201,7 +201,6 @@ ${phpcmd} ${mydir}/../list_valid_components/list_valid_components.php \
 
 # TODO: Run the acceptance tests for the affected components
 
-# ########## ########## ########## ##########
 # ########## ########## ########## ##########
 
 # Now we can proceed to delete all the files not being part of the
@@ -224,14 +223,13 @@ find ${WORKSPACE} -type f | grep -vf ${WORKSPACE}/work/patchset.files | xargs rm
 find ${WORKSPACE} -type d -depth -empty -not \( -name .git -o -name work -prune \) -delete
 
 # ########## ########## ########## ##########
-# ########## ########## ########## ##########
-
-# Now run all the checks that only need the patchset affected files
 
 # Disable exit-on-error for the rest of the script, it will
 # advance no matter of any check returning error. At the end
 # we will decide based on gathered information
 set +e
+
+# Now run all the checks that only need the patchset affected files
 
 # Run the upgrade savepoints checker, converting it to checkstyle format
 # (it requires to be installed in the root of the dir being checked)
@@ -254,7 +252,6 @@ ${phpcmd} ${mydir}/../coding_standards_detector/coding_standards_detector.php \
 ${phpcmd} ${mydir}/../../moodlecheck/cli/moodlecheck.php \
     --path=${WORKSPACE} --format=xml --componentsfile="${WORKSPACE}/work/valid_components.txt" > "${WORKSPACE}/work/docs.xml"
 
-# ########## ########## ########## ##########
 # ########## ########## ########## ##########
 
 # Everything has been generated in the work directory, generate the report, observing $filtering


### PR DESCRIPTION
This commit just moves the calculation of the components some lines
above, so we keep the 2 real check areas:
- checks requiring the whole code base.
- checks working against the changed files.

properly isolated. 1st step towards introducing the new "framework"
to specify, run and report new "pluggable" checks. Coming soon.
