### PR TITLE
MDLSITE-3422 ci: Various improvement to smurf files

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -276,7 +276,7 @@ ${phpcmd} ${mydir}/remote_branch_reporter.php \
 checksum="$(shasum ${WORKSPACE}/work/smurf.html | cut -d' ' -f1)"
 echo "SHA1: ${checksum}"
 
-if [[ "${checksum}" = "639b432e2a830fb4bc7dee41feb7534489bd2deb" ]]; then
+if [[ "${checksum}" = "af34cff8cae528c2f6ad1e93b9d1207179829be7" ]]; then
     echo "SMURFILE: OK"
 else
     echo "SMURFILE: FAILING"

--- a/remote_branch_checker/xslt/checkstyle2smurf.xsl
+++ b/remote_branch_checker/xslt/checkstyle2smurf.xsl
@@ -16,6 +16,8 @@
     <check>
       <xsl:attribute name="title"><xsl:value-of select="$title"/></xsl:attribute>
       <xsl:attribute name="url"><xsl:value-of select="$url"/></xsl:attribute>
+      <xsl:attribute name="numerrors"><xsl:value-of select="count(//error[@severity = 'error'])"/></xsl:attribute>
+      <xsl:attribute name="numwarnings"><xsl:value-of select="count(//error[@severity != 'error'])"/></xsl:attribute>
       <description>
         <xsl:value-of select="$description"/>
       </description>

--- a/remote_branch_checker/xslt/gargamel.xsl
+++ b/remote_branch_checker/xslt/gargamel.xsl
@@ -13,34 +13,56 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     </style>
   </head>
   <body>
-    <header><h1>Prechecker results:</h1></header>
+    <header>
+      <h1>Prechecker results:</h1>
+      <p>(<xsl:value-of select="//smurf/@numerrors"/> errors, <xsl:value-of select="//smurf/@numwarnings"/> warnings)</p>
+    </header>
     <main>
       <xsl:for-each select="smurf/check">
         <article>
           <h2><xsl:value-of select="@title"/></h2>
+          <p>(<xsl:value-of select="@numerrors"/> errors, <xsl:value-of select="@numwarnings"/> warnings)</p>
           <p><xsl:value-of select="description"/></p>
           <dl>
             <xsl:for-each select="mess/problem">
-                <dt><xsl:attribute name="class">priority<xsl:value-of select="@weight"/></xsl:attribute><xsl:value-of select="@file"/></dt>
-                <dd>Lines: <xsl:value-of select="@linefrom"/>-<xsl:value-of select="@lineto"/></dd>
-                <dd><a class="text-error"><xsl:attribute name="href"><xsl:value-of select="@url"/></xsl:attribute><xsl:value-of select="message"/></a></dd>
-                <dd>
-                  <details><summary>Details:</summary>
-                    <dl class="dl-horizontal">
-                        <dt>API</dt>
-                        <dd><xsl:value-of select="@api"/></dd>
-                        <dt>Package</dt>
-                        <dd><xsl:value-of select="@package"/></dd>
-                        <dt>Class</dt>
-                        <dd><xsl:value-of select="@class"/></dd>
-                        <dt>Method</dt>
-                        <dd><xsl:value-of select="@method"/></dd>
-                        <dt>Ruleset</dt>
-                        <dd><xsl:value-of select="@ruleset"/></dd>
-                        <dt>Rule</dt>
-                        <dd><xsl:value-of select="@rule"/></dd>
-                        <dt>Code</dt>
-                        <dd><xsl:value-of select="code"/></dd>
+              <xsl:choose>
+                <xsl:when test="@file = preceding-sibling::problem[1]/@file">
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:if test="preceding-sibling::problem[1]/@file">
+                    <hr/>
+                  </xsl:if>
+                  <dt><xsl:value-of select="@file"/></dt>
+                </xsl:otherwise>
+              </xsl:choose>
+              <dd>
+                <xsl:attribute name="class">text-<xsl:value-of select="@type"/></xsl:attribute>
+                  <xsl:if test="@linefrom != 0">(#<xsl:value-of select="@linefrom"/>
+                    <xsl:if test="@lineto != 0 and @lineto != @linefrom">-<xsl:value-of select="@lineto"/></xsl:if>)
+                  </xsl:if>
+                <a>
+                  <xsl:attribute name="class">text-<xsl:value-of select="@type"/></xsl:attribute>
+                  <xsl:attribute name="href"><xsl:value-of select="@url"/></xsl:attribute>
+                  <xsl:value-of select="message"/>
+                </a>
+              </dd>
+              <dd>
+                <details class="muted"><summary>Details:</summary>
+                  <dl class="dl-horizontal">
+                    <dt>API</dt>
+                      <dd><xsl:value-of select="@api"/></dd>
+                      <dt>Package</dt>
+                      <dd><xsl:value-of select="@package"/></dd>
+                      <dt>Class</dt>
+                      <dd><xsl:value-of select="@class"/></dd>
+                      <dt>Method</dt>
+                      <dd><xsl:value-of select="@method"/></dd>
+                      <dt>Ruleset</dt>
+                      <dd><xsl:value-of select="@ruleset"/></dd>
+                      <dt>Rule</dt>
+                      <dd><xsl:value-of select="@rule"/></dd>
+                      <dt>Code</dt>
+                      <dd><xsl:value-of select="code"/></dd>
                     </dl>
                   </details>
                 </dd>


### PR DESCRIPTION
This commit solves/improves these:

XML:
- Added "numerrors" and "numwarnings" attributes to every check.
- Added grand totals for the above to the "smurf" element.

HTML:
- Show the new totals from the XML.
- Group problems by file, clearly separanting them.
- Difference errors (red) and warnings (orange).
- Cleverer handling of line numbers.
- Dim the "details" section to make it less prominent.

And, of course, update the hash-hack to detect 100% correct results
(note this will be replaced by a better solution in MDLSITE-3423)
