### PR TITLE
NOBUG: Avoid a notice caused by undefined $CFG->libdir

### DIFF
--- a/list_valid_components/list_valid_components.php
+++ b/list_valid_components/list_valid_components.php
@@ -98,6 +98,7 @@ if (file_exists($options['basedir'] . '/lib/classes/component.php')) {
     global $CFG;
     $CFG = new stdClass();
     $CFG->dirroot = $options['basedir'];
+    $CFG->libdir = $CFG->dirroot . '/lib';
     $CFG->admin = 'admin';
     require_once($CFG->dirroot . '/lib/classes/component.php');
 


### PR DESCRIPTION
MDL-47195 introduced a new PSR0 autoloader and a new
requirement, needing libdir to be defined. We don't use such PSR0
at all, but it's executed so need it defined. This patch
just fulfills that new requirement.
