### PR TITLE
MDLSITE-3608 php_lint: fix error handling on difference compairsons

### DIFF
--- a/php_lint/php_lint.sh
+++ b/php_lint/php_lint.sh
@@ -32,8 +32,8 @@ if [[ ${fulllint} -ne 1 ]]; then
     # list_changed_files.sh and invoke it
     export initialcommit=${GIT_PREVIOUS_COMMIT}
     export finalcommit=${GIT_COMMIT}
-    mfiles=$(${mydir}/../list_changed_files/list_changed_files.sh)
-    if [[ ${PIPESTATUS[0]} -eq 0 ]]; then
+    if mfiles=$(${mydir}/../list_changed_files/list_changed_files.sh)
+    then
         echo "Running php syntax check from $initialcommit to $finalcommit:"
     else
         echo "Problems getting the list of changed files. Defaulting to full lint"


### PR DESCRIPTION
Previous error handling relied on non-strict error checking, so when the list_changed_files.sh died without useful output, this script died without useful output.

Now it'll default back to a full lint as desired.

You can test it with this:

```
#!/bin/bash
set -e

export gitcmd=/usr/local/bin/git
export phpcmd=/usr/local/bin/php
export gitdir=/Users/danp/www/im
# Set to this to see it do full lint:
export GIT_PREVIOUS_COMMIT=random-junk-or-whatever
# To do incremental:
export GIT_PREVIOUS_COMMIT=293f1b4d85d5a9b4b22b8e37eb2283f9a0b04157
export GIT_COMMIT=3d4de122f20830405b3e0d0f653c88851e5e2777

./php_lint.sh
```
