### PR TITLE
MDLSITE-3612 - support csslint checking of CSS

### DIFF
--- a/remote_branch_checker/lib.php
+++ b/remote_branch_checker/lib.php
@@ -84,6 +84,21 @@ class remote_branch_reporter {
             }
         }
 
+        // Process the csslint output, weighting errors with 5 and warnings with 1
+        $params = array(
+            'title' => 'CSS problems',
+            'description' => 'This section shows CSS problems detected by csslint',
+            'url' => 'https://github.com/CSSLint/csslint/wiki/Rules', //TODO: MDLSITE-1796 Create CSS guidelines and link them here.
+            'codedir' => dirname($this->directory) . '/',
+            'errorweight' => 5,
+            'warningweight' => 1);
+        if ($node = $this->apply_xslt($params, $this->directory . '/csslint.xml', 'checkstyle2smurf.xsl')) {
+            if ($check = $node->getElementsByTagName('check')->item(0)) {
+                $snode = $doc->importNode($check, true);
+                $smurf->appendChild($snode);
+            }
+        }
+
         // Process the docs output, weighting errors with 3 and warnings with 1
         $params = array(
             'title' => 'PHPDocs style problems',
@@ -123,21 +138,6 @@ class remote_branch_reporter {
             'errorweight' => 50,
             'warningweight' => 10);
         if ($node = $this->apply_xslt($params, $this->directory . '/savepoints.xml', 'checkstyle2smurf.xsl')) {
-            if ($check = $node->getElementsByTagName('check')->item(0)) {
-                $snode = $doc->importNode($check, true);
-                $smurf->appendChild($snode);
-            }
-        }
-
-        // Process the csslint output, weighting errors with 5 and warnings with 1
-        $params = array(
-            'title' => 'CSS problems',
-            'description' => 'This section shows CSS problems detected by csslint',
-            'url' => 'https://github.com/CSSLint/csslint/wiki/Rules', //TODO: MDLSITE-1796 Create CSS guidelines and link them here.
-            'codedir' => dirname($this->directory) . '/',
-            'errorweight' => 5,
-            'warningweight' => 1);
-        if ($node = $this->apply_xslt($params, $this->directory . '/csslint.xml', 'checkstyle2smurf.xsl')) {
             if ($check = $node->getElementsByTagName('check')->item(0)) {
                 $snode = $doc->importNode($check, true);
                 $smurf->appendChild($snode);

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -309,7 +309,7 @@ ${phpcmd} ${mydir}/remote_branch_reporter.php \
 checksum="$(shasum ${WORKSPACE}/work/smurf.html | cut -d' ' -f1)"
 echo "SHA1: ${checksum}"
 
-if [[ "${checksum}" = "4775ff9d36c000856985ccdf29fc496d759b602f" ]]; then
+if [[ "${checksum}" = "692f3061e9ece0acd032c6e8e06ddff060a76eae" ]]; then
     echo "SMURFILE: OK"
 else
     echo "SMURFILE: FAILING"

--- a/remote_branch_checker/xslt/gargamel.xsl
+++ b/remote_branch_checker/xslt/gargamel.xsl
@@ -9,14 +9,21 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <meta charset="utf-8"/>
     <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.no-icons.min.css" rel="stylesheet"/>
     <style type="text/css">
-        body { margin: 2em; }
+        body { margin: 0.5em 2em; }
+        h1 { font-size: 20px; line-height: 21px; margin:3px 0; }
+        h2 { font-size: 18px; line-height: 19px; margin:3px 0; }
+        dl { margin: 5px 5px;}
+        hr { margin: 5px 0; }
+        p  { margin:0 0 5px; }
+        .total-counts { font-weight: bold; }
     </style>
   </head>
   <body>
     <header>
       <h1>Prechecker results:</h1>
-      <p>(<xsl:value-of select="//smurf/@numerrors"/> errors, <xsl:value-of select="//smurf/@numwarnings"/> warnings)</p>
+      <p class="total-counts">(<xsl:value-of select="//smurf/@numerrors"/> errors, <xsl:value-of select="//smurf/@numwarnings"/> warnings)</p>
     </header>
+    <hr />
     <main>
       <xsl:for-each select="smurf/check">
         <article>
@@ -29,9 +36,6 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
                 <xsl:when test="@file = preceding-sibling::problem[1]/@file">
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:if test="preceding-sibling::problem[1]/@file">
-                    <hr/>
-                  </xsl:if>
                   <dt><xsl:value-of select="@file"/></dt>
                 </xsl:otherwise>
               </xsl:choose>
@@ -69,6 +73,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
             </xsl:for-each>
           </dl>
         </article>
+        <hr />
       </xsl:for-each>
     </main>
   </body>


### PR DESCRIPTION
Since it reports in checkstyle format we can use existing reporting mechanisms much like the other changes.

You need to npm install -g csslint.

You can test it with this:

```
#!/bin/bash
set -e

export gitcmd=/usr/local/bin/git
export phpcmd=/usr/local/bin/php
export jshintcmd=/usr/local/bin/jshint
export csslintcmd=/usr/local/bin/csslint
export gitdir=/Users/danp/www/im
export WORKSPACE=/Users/danp/Desktop/workspace
export remote=git://github.com/danpoltawski/moodle.git
export branch=csslint-test1
export integrateto=master

./remote_branch_checker.sh
```

And there are these three tests:
1.  `git://github.com/danpoltawski/moodle.git csslint-test1` - this should not do any checking because there are no CSS files changed (you should see message in output)
2.  `git://github.com/danpoltawski/moodle.git csslint-test2` - this should run the linter with the .csslintrc config settings provided and you should see 1 error and 1 warning (duplicate rule and bad definition)
3.   `git://github.com/danpoltawski/moodle.git csslint-test3` - this should default to only the error checking as no csshintrc file exists in the repo, so you should see a message about it using only error checking and you should only get the parse error reported (not the duplicate rule)
