### PR TITLE
MDLSITE-3612 fix for lack of ignore config

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -285,6 +285,7 @@ then
     if [ ! -f ${WORKSPACE}/.csslintrc ]; then
         echo "csslintrc file not found, defaulting to error checking only"
         echo '--errors=errors' > ${WORKSPACE}/.csslintrc
+        echo '--exclude-list=vendor/,lib/editor/tinymce/,lib/yuilib/,theme/bootstrapbase/style/' >> ${WORKSPACE}/.csslintrc
     fi
     ${csslintcmd} --format=checkstyle-xml --quiet ${WORKSPACE} > "${WORKSPACE}/work/csslint.xml"
 else


### PR DESCRIPTION
In fallback error checking - will not be a problem when MDL-48277 lands, but that won't take effect until it enters moodle.git at the end of this week (or for non-supported branches..)
