### PR TITLE
MDLSITE-3647 - fix csslint when only ignored css files found

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -297,9 +297,9 @@ then
     echo "No checkable CSS files detected in patchset."
     echo '<?xml version="1.0" encoding="utf-8"?><checkstyle></checkstyle>' > "${WORKSPACE}/work/csslint.xml"
 else
-    echo "Unknown csslint error occured:"
+    echo "Unknown csslint error occured. See csslint.out" >> ${errorfile}
+    echo 'csslint exited with error:'
     cat ${WORKSPACE}/work/csslint.out
-    exit 1;
 fi
 
 # ########## ########## ########## ##########


### PR DESCRIPTION
This can be tested using same instructions as #27

Additionally using branch of Mary's which detected this problem: git://github.com/lazydaisy/moodle wip-MDL-48160_master
