### PR TITLE
MDLSITE-3252 check for third party library modifications

### DIFF
--- a/remote_branch_checker/lib.php
+++ b/remote_branch_checker/lib.php
@@ -171,6 +171,23 @@ class remote_branch_reporter {
             }
         }
 
+        // Process the thirdparty output, weighting errors with 5 and warnings with 1
+        $params = array(
+            'title' => 'Third party library modification problems',
+            'abbr' => 'thirdparty',
+            'description' => 'This section shows problems detected with the modification of third party libraries',
+            'url' => 'https://docs.moodle.org/dev/Peer_reviewing#Third_party_code',
+            'codedir' => dirname($this->directory) . '/',
+            'errorweight' => 5,
+            'warningweight' => 1,
+            'allowfiltering' => 0);
+        if ($node = $this->apply_xslt($params, $this->directory . '/thirdparty.xml', 'checkstyle2smurf.xsl')) {
+            if ($check = $node->getElementsByTagName('check')->item(0)) {
+                $snode = $doc->importNode($check, true);
+                $smurf->appendChild($snode);
+            }
+        }
+
         // Conditionally, perform the filtering
         if ($patchset) {
             $this->patchset_filter($doc, $patchset);

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -228,6 +228,9 @@ export GIT_PREVIOUS_COMMIT=${ancestor}
 export GIT_COMMIT=${integrateto}_precheck
 ${mydir}/../php_lint/php_lint.sh > "${WORKSPACE}/work/phplint.txt"
 cat "${WORKSPACE}/work/phplint.txt" | ${phpcmd} ${mydir}/../php_lint/phplint2checkstyle.php > "${WORKSPACE}/work/phplint.xml"
+
+${mydir}/../thirdparty_check/thirdparty_check.sh > "${WORKSPACE}/work/thirdparty.txt"
+cat "${WORKSPACE}/work/thirdparty.txt" | ${phpcmd} ${mydir}/../thirdparty_check/thirdparty2checkstyle.php > "${WORKSPACE}/work/thirdparty.xml"
 # ########## ########## ########## ##########
 
 # Now we can proceed to delete all the files not being part of the

--- a/thirdparty_check/thirdparty2checkstyle.php
+++ b/thirdparty_check/thirdparty2checkstyle.php
@@ -1,0 +1,81 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Convert thirdparty.txt files to checkstyle xml format
+ *
+ * This script will convert the (textual) output from third party library modification
+ * info the checkstyle-like xml formal for easier integration in other CI tools/reports.
+ * It's used by * some jobs like the remote_branch_checker one.
+ *
+ * @category   ci
+ * @package    local_ci
+ * @subpackage thirdparty_check
+ * @copyright  2014 Dan Poltawski
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+define('CLI_SCRIPT', true);
+define('NO_OUTPUT_BUFFERING', true);
+
+require(dirname(dirname(dirname(dirname(__FILE__)))).'/config.php');
+require_once($CFG->libdir.'/clilib.php');      // cli only functions
+
+// now get cli options
+list($options, $unrecognized) = cli_get_params(
+    array('help' => false),
+    array('h' => 'help'));
+
+if ($unrecognized) {
+    $unrecognized = implode("\n  ", $unrecognized);
+    cli_error(get_string('cliunknowoption', 'admin', $unrecognized));
+}
+
+if ($options['help']) {
+    $help =
+"Convert third_party text output to checkstyle xml format
+
+Options:
+-h, --help            Print out this help
+
+Example:
+\$sudo -u www-data /usr/bin/php local/ci/thirdparty_check/thirdparty2checkstyle.php < file.txt > file.xml
+";
+    echo $help;
+    exit(0);
+}
+
+// Output begins, we always produce the preamble and checkstyle container.
+$output = '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL .
+'<checkstyle version="1.3.2">' . PHP_EOL;
+
+while ($line = trim(fgets(STDIN))) {
+    if (preg_match('/^(\S+) \- WARN: (.*)/', $line, $matches)) {
+        $filename = $matches[1];
+        $message = $matches[2];
+        // FIXME: In the future it would be great to work out from the git-diff the line number and 
+        // be able to supply it here..
+        $lineno = 0;
+
+        $output.= '<file name="' . $filename. '">'.PHP_EOL;
+        $output.= '<error line="'.$lineno.'" column="0" severity="warning" ';
+        $output.= 'message="' .s($message). ' "/>' . PHP_EOL;
+        $output.= '</file>';
+    }
+}
+$output .= '</checkstyle>';
+
+echo $output;

--- a/thirdparty_check/thirdparty_check.sh
+++ b/thirdparty_check/thirdparty_check.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# $WORKSPACE: Path to the directory where test reults will be sent
+# $phpcmd: Path to the PHP CLI executable
+# $gitdir: Directory containing git repo
+# $initalcommit
+# $finalcommit
+
+set -e
+
+# Verify everything is set
+required="WORKSPACE phpcmd gitdir initialcommit finalcommit"
+for var in $required; do
+    if [ -z "${!var}" ]; then
+        echo "ERROR: ${var} environment variable is not defined. See the script comments."
+        exit 1
+    fi
+done
+
+# calculate some variables
+mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if ${mydir}/../list_changed_files/list_changed_files.sh > ${WORKSPACE}/modified_files.txt
+then
+    echo "INFO: Checking for third party modifications from $initialcommit to $finalcommit"
+else
+    echo "ERROR: Problems getting the list of changed files."
+    exit 1
+fi
+
+# Generate the list of valid component directories  and use that to generate third party locations
+${mydir}/../list_valid_components/list_valid_components.sh |grep $gitdir | cut -d , -f3 > "${WORKSPACE}/component_directories.txt"
+$phpcmd ${mydir}/thirdpartylocations.php < $WORKSPACE/component_directories.txt > $WORKSPACE/thirdpartylocations.txt
+
+while read thirdpartyinfo; do
+    # Strip the directory info out for grepping purposes.
+    directorylessinfo=`echo $thirdpartyinfo | sed "s#$gitdir/##g"`
+
+    # Get a search string to find modified files.
+    search=`echo $directorylessinfo | cut -d, -f1`
+
+    if matches=$(grep "$search" ${WORKSPACE}/modified_files.txt)
+    then
+        echo "INFO: Detected third party modification in $search"
+        thirdpartyfile=`echo $directorylessinfo | cut -d, -f2`
+        if grep -q $thirdpartyfile ${WORKSPACE}/modified_files.txt
+        then
+            echo "INFO: OK $thirdpartyfile modified"
+        else
+            readmefile=`echo $directorylessinfo | cut -d, -f3`
+            if grep -q $readmefile ${WORKSPACE}/modified_files.txt
+            then
+                echo "INFO: OK $readmefile modified"
+            else
+                while read -r file; do
+                    fullpath=$gitdir/$file
+                    echo "$fullpath - WARN: modification to third party library ($search) without update to $thirdpartyfile or ${readmefile}"
+                done <<< "$matches"
+            fi
+        fi
+    fi
+done <$WORKSPACE/thirdpartylocations.txt
+
+exit 0

--- a/thirdparty_check/thirdpartylocations.php
+++ b/thirdparty_check/thirdpartylocations.php
@@ -1,0 +1,83 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Given a list of component directories, returns a list of third party
+ * library directories (defined by thirdpartylibs.xml)
+ *
+ * @category   ci
+ * @package    local_ci
+ * @subpackage thirdparty_check
+ * @copyright  2014 Dan Poltawski
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+
+while ($dir = trim(fgets(STDIN))) {
+    $xmlfile = $dir.'/thirdpartylibs.xml';
+    print_thirdparty_info($xmlfile, $dir);
+    $libxmlfile = $dir.'/lib/thirdpartylibs.xml';
+    print_thirdparty_info($libxmlfile, $dir.'/lib');
+}
+
+/**
+ * print thirdparty directories info from xmlfile path, echos the
+ * info out in format:
+ * pathofdirectory,pathtothirdpartyxmlfile,pathtoreadmemoodle
+ *
+ * @param string $xmlfile the file to get directories from
+ * @param string $basepath the path to base directories of
+ */
+function print_thirdparty_info($xmlfile, $basepath) {
+        if (!file_exists($xmlfile)) {
+            return;
+        }
+        $simplexml = simplexml_load_file($xmlfile);
+        $subdirectories = $simplexml->xpath('//libraries/library/location');
+
+        $dirs = array();
+        foreach ($subdirectories as $subdirectory) {
+            $path = $basepath.'/'.$subdirectory;
+
+            // Workout a path for the readme file..
+            if (strpos(basename($subdirectory), '.') !== false) {
+                // Its a filename,the filename from the directory.
+                $readmesubdir = dirname($subdirectory);
+            } else {
+                $readmesubdir = $subdirectory;
+            }
+
+            if ($readmesubdir == '.') {
+                $readmepath = $basepath;
+            } else {
+                $readmepath = $basepath.'/'.$readmesubdir;
+            }
+
+            // Readme search, NOTE intentional duplicate on the end to default to in the case
+            // NOTE the README_MOODLE.txt can have problems on HFS+!!
+            // TODO: We should make these readme files get named consitently..
+            $readmenames = array('readme_moodle.txt', 'moodle_readme.txt', 'README_MOODLE.txt', 'readme_moodle.txt');
+            $readme = ''; // Will end up as 'readme_moodle.txt' if reach the end of this looop.
+            foreach ($readmenames as $readmename) {
+                $readme = $readmepath.'/'.$readmename;
+                if (file_exists($readme)) {
+                    break;
+                }
+            }
+
+            echo $path.','.$xmlfile.','.$readme."\n";
+        }
+}


### PR DESCRIPTION
This check will try and find modification to third party libraries
and warn about them if the thirdpartylibs.xml or readme_moodle.txt has
not been updated.

To test you can use the branch:
`git://github.com/danpoltawski/moodle.git thirdparty-test1`

Some things you can note in testing:
https://github.com/danpoltawski/moodle/commit/eada3650769da60d09d31cb5a233662e4f0ad7fd is detected as modification to addodb
https://github.com/danpoltawski/moodle/commit/3eaf3c1a158014f0406ae6d00b474b9c4dff90a8 is detected as modification to rangy
https://github.com/danpoltawski/moodle/commit/29a6bab8379c8363e0c4329e670efb26a03f6119 is detected but not warned about because of https://github.com/danpoltawski/moodle/commit/7eafb8a0b4e2dd92a5687c25edf64e75b3bb761e (confirm by reading the thirdparty.txt) 
https://github.com/danpoltawski/moodle/commit/0e1a1c2a01c01f74f7f795485c4b85ec4b5877cc is detected but the message doesn't mention readme_moodle.txt, but instead the existing moodle_readme.txt

Sidenote: I think these things could become an error at the point when the readme_moodle.txt file was always known. (Not the case here, we guess)
