### PR TITLE
CONTRIB-4696 Make CI exclusions aware of distributed thirdpartylibs.xml 

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -81,6 +81,8 @@ if [[ -n "${BUILD_TAG}" ]] && [[ ! "${issue}" = "" ]]; then
 fi
 
 # List of excluded dirs
+export gitdir="${WORKSPACE}"
+export gitbranch="${integrateto}"
 . ${mydir}/../define_excluded/define_excluded.sh
 
 # Create the work directory where all the tasks will happen/be stored
@@ -272,7 +274,6 @@ set +e
 #    ${excluded_list} --quiet --log-pmd "${WORKSPACE}/work/cpd.xml" ${WORKSPACE}
 
 # Set some variables used by various scripts.
-export gitdir="${WORKSPACE}"
 export issuecode=${issue}
 export initialcommit=${basecommit}
 export GIT_PREVIOUS_COMMIT=${initialcommit}


### PR DESCRIPTION
While the local_codechecker already had support for the exclusion of thirdpartylibs... CI jobs (define_excluded) was missing it and instead we were using a fixed list.

With these changes (already tested by David @ laptop), all CI jobs will be able to get a better list of excluded stuff, automatically, not requiring changes to the fixed list but getting paths from thirdpartylibs information.

The laptop has been also running the usual CI jobs for the last 5-6 hours with this patch applied, apparently without a problem.

https://tracker.moodle.org/browse/CONTRIB-4696

Ciao :-)