### PR TITLE
MDLSITE-3799 ci: reset fixfor versions when moving out from integration.

### DIFF
--- a/tracker_automations/mv_reopened_out_from_current/mv_reopened_out_from_current.sh
+++ b/tracker_automations/mv_reopened_out_from_current/mv_reopened_out_from_current.sh
@@ -57,6 +57,7 @@ for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
     ${basereq} --action progressIssue \
         --issue ${issue} \
         --step "CI Global Self-Transition" \
+        --fixVersions "" \
         --custom "customfield_10211:" \
         --comment "Moving this reopened issue out from current integration. Please, re-submit it for integration once ready."
     echo "$BUILD_NUMBER $BUILD_ID ${issue}" >> "${logfile}"


### PR DESCRIPTION
Reopened issues that have failed in the testing phase, already have got
their fixfor versions set. Once they are reopened and moved out from
current integration cycle those fixfor versions, now incorrect, remain
set.

This change just ensures that any issue moved out from integration
(reopened) gets the versions cleaned.