### PR TITLE
MDLSITE-4018 bulk-checker: process all awaiting integration issues

### DIFF
--- a/tracker_automations/bulk_precheck_issues/criteria/awaiting_integration/query.sh
+++ b/tracker_automations/bulk_precheck_issues/criteria/awaiting_integration/query.sh
@@ -3,7 +3,6 @@ ${basereq} --action getIssueList \
                  AND status = 'Waiting for integration review' \
                  AND (labels IS EMPTY OR labels NOT IN (ci, security_held, integration_held)) \
                  AND level IS EMPTY \
-                 AND 'Currently in integration' IS NOT EMPTY \
                  ORDER BY priority DESC, votes DESC, 'Last comment date' ASC" \
            --outputFormat 101 \
            --file "${resultfile}"


### PR DESCRIPTION
Before this, only the oned under current integration were
being checked and that was leading, on continuous periods,
where everything happens quickly to some issues never checked.

With this change we'll start to process any issue awaiting integration
that never has been checked before (missing ci label).