### PR TITLE
MDLSITE-3899 Stop running jshint on built folders

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -371,8 +371,8 @@ ${phpcmd} ${mydir}/../coding_standards_detector/coding_standards_detector.php \
 ${phpcmd} ${mydir}/../../moodlecheck/cli/moodlecheck.php \
     --path=${WORKSPACE} --format=xml --componentsfile="${WORKSPACE}/work/valid_components.txt" > "${WORKSPACE}/work/docs.xml"
 
-# Generate the built yui directories present to exclude from jshint..
-find $WORKSPACE -type d -path \*/build/\* | sed "s|$WORKSPACE/||" > $WORKSPACE/.jshintignore
+# Exclude build directories from the results (e.g. lib/yui/build, lib/amd/build/)
+find $WORKSPACE -type d -path \*/build | sed "s|$WORKSPACE/||" > $WORKSPACE/.jshintignore
 
 # Run the JSHINT (using the checked out .jshint file)
 ${jshintcmd} --config $WORKSPACE/.jshintrc --exclude-path $WORKSPACE/.jshintignore \


### PR DESCRIPTION
The problem was the existing rule relied on having subdirectories (i.e.
lib/yui/build/some-random-module/built.js for yui). Where as amd doesn't
have this strcuture so its just lib/amd/build/some-module-min.js). Doing
it this way means a more blanket ignore for yui, but think thats
desierable anyway.

Branch to test this with:
git://github.com/danpoltawski/moodle.git jshinttest

(Test branch Includes 3 commits off master which change yui/amd and normal srv/build direcories)