### PR TITLE
NOBUG: Avoid weird dereferenced links std behavior.

### DIFF
--- a/grunt_process/grunt_process.sh
+++ b/grunt_process/grunt_process.sh
@@ -56,7 +56,7 @@ else
 fi
 
 # Linking it.
-ln -fs ${npmbase}/${gitbranch}/node_modules ${gitdir}/node_modules
+ln -nfs ${npmbase}/${gitbranch}/node_modules ${gitdir}/node_modules
 
 # Verify there is a grunt executable available, installing everrything if missing
 if [[ ! -f ${gitdir}/node_modules/grunt-cli/bin/grunt ]]; then

--- a/prepare_composer_stuff/prepare_composer_stuff.sh
+++ b/prepare_composer_stuff/prepare_composer_stuff.sh
@@ -50,4 +50,4 @@ echo "Linking ${composerdir}/vendor from ${gitdir}/vendor"
 if [[ -L ${gitdir}/vendor ]]; then
     rm -f ${gitdir}/vendor
 fi
-ln -s ${composerdir}/vendor ${gitdir}/vendor
+ln -nfs ${composerdir}/vendor ${gitdir}/vendor


### PR DESCRIPTION
By default, ln itself follows links so, at the end
it's highly possible to get them recursively created
no matter they already exists. To solve this the -n
flag can be used, causing ln not to follow links.

Or, something like that, really I've not thought too
much about it. I just tried the flag and verified it
solved the problem, so applying it everywhere.

Ref: http://www.gossamer-threads.com/lists/linux/kernel/1966