### PR TITLE
NOBUG: Format XML output adding linefeeds and indentation

### DIFF
--- a/remote_branch_checker/lib.php
+++ b/remote_branch_checker/lib.php
@@ -53,6 +53,7 @@ class remote_branch_reporter {
 
         // Main smurf Dom where everything will be aggregated
         $doc = new DomDocument();
+        $doc->formatOutput = true; // To workaround some "sed" limits with too long lines.
         $smurf = $doc->createElement('smurf');
         $smurf->setAttribute('version', '0.9.1');
 


### PR DESCRIPTION
This will prevent some utilities (sed) breaking badly
against loooong reports leading to "too long line" problems.


Old failure (had to abort it after minutes):

http://integration.moodle.org/job/Precheck%20remote%20branch/16455/

With patch applied, in the laptop, ended in seconds:

http://ci.stronk7.com/view/prehecker/job/Precheck%20remote%20branch/1577/

So it should be ok, ciao :-)