### PR TITLE
MDLSITE-4198 ci: split maxcommits into warning(10) and error(100)

### DIFF
--- a/tracker_automations/set_integration_priority_to_one/set_integration_priority_to_one.sh
+++ b/tracker_automations/set_integration_priority_to_one/set_integration_priority_to_one.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Look for issues known to need their integration priority raised.
+#jiraclicmd: fill execution path of the jira cli
+#jiraserver: jira server url we are going to connect to
+#jirauser: user that will perform the execution
+#jirapass: password of the user
+#mustfixversion: textual "must fix for X.Y" version to raise integration priority to 1.
+
+# Let's go strict (exit on error)
+set -e
+
+# Verify everything is set
+required="WORKSPACE jiraclicmd jiraserver jirauser jirapass mustfixversion"
+for var in $required; do
+    if [ -z "${!var}" ]; then
+        echo "Error: ${var} environment variable is not defined. See the script comments."
+        exit 1
+    fi
+done
+
+# file where results will be sent
+resultfile=$WORKSPACE/set_integration_priority_to_one.csv
+echo -n > "${resultfile}"
+
+# file where updated entries will be logged
+logfile=$WORKSPACE/set_integration_priority_to_one.log
+
+# Calculate some variables
+mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+basereq="${jiraclicmd} --server ${jiraserver} --user ${jirauser} --password ${jirapass}"
+BUILD_TIMESTAMP="$(date +'%Y-%m-%d_%H-%M-%S')"
+
+# Note this could be done by one unique "runFromIssueList" action, but we are splitting
+# the search and the update in order to log all the reopenend issues within jenkins ($logfile)
+
+# Let's search all the issues in Moodle project having zero integration priority and
+# being under current integration or awaiting integration. Raise integration priority
+# for those having the mdlqa label or a given mustfixversion.
+${basereq} --action getIssueList \
+           --search "project = 'Moodle' \
+                 AND 'Integration priority' = 0 \
+                 AND ( \
+                       'Currently in integration' = 'Yes' \
+                       OR status = 'Waiting for integration review' \
+                     ) \
+                 AND ( \
+                       labels IN (mdlqa)
+                       OR fixVersion = '${mustfixversion}' \
+                     )" \
+           --file "${resultfile}"
+
+# Iterate over found issues and set their integration priority (customfield_12210) to 1.
+for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
+    echo "Processing ${issue}"
+    ${basereq} --action progressIssue \
+        --issue ${issue} \
+        --step "CI Global Self-Transition" \
+        --custom "customfield_12210:1"
+    echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue}" >> "${logfile}"
+done
+
+# Remove the resultfile. We don't want to disclose those details.
+rm -fr "${resultfile}"


### PR DESCRIPTION
To better support branches with a number of commits, the old, unique,
maxcommits setting is changed plugin-wide to use a couple of settings
instead.

Also, we are moving from an eroor&stop behavior (where the rest of the
checks were not applied) to a error/warn and continue behavior, by
showing the maxcommits warnings and errors within the commits checker.

This may lead to problems is somebody does submit a huge/wrong branch,
but that also was happening right now irrespectively of the # of
commits. If we need countermeasures for that situation, time will tell.