### PR TITLE
MDLSITE-4198 ci: split maxcommits into warning(10) and error(100)

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -9,7 +9,8 @@
 # $issue: Issue code that requested the precheck. Empty means that Jira won't be notified.
 # $filtering: Report about only modified lines (default, true), or about the whole files (false)
 # $format: Format of the final smurf file (xml | html). Defaults to html.
-# $maxcommits: Max number of commits accepted per run. Error if exceeded. Defaults to 15.
+# $maxcommitswarn: Max number of commits accepted per run. Warning if exceeded. Defaults to 10.
+# $maxcommitserror: Max number of commits accepted per run. Error if exceeded. Defaults to 100.
 # $rebasewarn: Max number of days allowed since rebase. Warning if exceeded. Defaults to 20.
 # $rebaseerror: Max number of days allowed since rebase. Error if exceeded. Defaults to 60.
 # $extrapath: Extra paths to be available (global)
@@ -28,7 +29,8 @@ fi
 # Apply some defaults
 filtering=${filtering:-true}
 format=${format:-html}
-maxcommits=${maxcommits:-15}
+maxcommitswarn=${maxcommitswarn:-10}
+maxcommitserror=${maxcommitserror:-100}
 rebasewarn=${rebasewarn:-20}
 rebaseerror=${rebaseerror:-60}
 gcinterval=${gcinterval:-25}
@@ -227,12 +229,7 @@ if [[ ${exitstatus} -ne 0 ]]; then
 fi
 set -e
 
-# Verify the number of commits
-numcommits=$(${gitcmd} log ${basecommit}..${integrateto}_precheck --oneline --no-merges | wc -l)
-if [[ ${numcommits} -gt ${maxcommits} ]]; then
-    echo "Error: The ${branch} branch at ${remote} exceeds the maximum number of commits ( ${numcommits} > ${maxcommits})" | tee -a ${errorfile}
-    exit 1
-fi
+# Verify the number of commits. Now this is handled by the verify_commit_messages check.
 
 # Calculate the differences and store them
 ${gitcmd} diff ${basecommit}..${integrateto}_precheck > ${WORKSPACE}/work/patchset.diff
@@ -309,6 +306,8 @@ set +e
 
 # Set some variables used by various scripts.
 export issuecode=${issue}
+export maxcommitswarn=${maxcommitswarn}
+export maxcommitserror=${maxcommitserror}
 export initialcommit=${basecommit}
 export GIT_PREVIOUS_COMMIT=${initialcommit}
 export finalcommit=${integrateto}_precheck

--- a/tracker_automations/bulk_precheck_issues/bulk_precheck_issues.sh
+++ b/tracker_automations/bulk_precheck_issues/bulk_precheck_issues.sh
@@ -8,7 +8,8 @@
 #cf_branches: pairs of moodle branch and id for "Pull XXXX Branch" custom field (master:customfield_10111,....)
 #cf_testinginstructions: id for testing instructions custom field (customfield_10117)
 #criteria: "awaiting peer review", "awaiting integration", "developer request"
-#maxcommits: max number of commits allowed in the branch. Defaults to 100.
+#$maxcommitswarn: Max number of commits accepted per run. Warning if exceeded. Defaults to 10.
+#$maxcommitserror: Max number of commits accepted per run. Error if exceeded. Defaults to 100.
 #quiet: if enabled ("true"), don't perform any action in the Tracker.
 #jenkinsjobname: job in the server that we are going to execute
 #jenkinsserver: private jenkins server url (where the prechecker will be executed.
@@ -50,8 +51,9 @@ fi
 
 echo "Using criteria: ${criteria}"
 
-# Maxcommits limit to apply, defaulting to 100.
-maxcommits=${maxcommits:-100}
+# Apply some defaults
+maxcommitswarn=${maxcommitswarn:-10}
+maxcommitserror=${maxcommitserror:-100}
 
 # Include some utility functions
 . "${mydir}/util.sh"
@@ -125,7 +127,8 @@ while read issue; do
                       build "${jenkinsjobname}" \
                       -p "remote=${repository}" -p "branch=${branch}" \
                       -p "integrateto=${target}" -p "issue=${issue}" \
-                      -p "filtering=true" -p "format=html" -p "maxcommits=${maxcommits}" \
+                      -p "filtering=true" -p "format=html" \
+                      -p "maxcommitswarn=${maxcommitswarn}" -p "maxcommitserror=${maxcommitserror}" \
                       -s -v > "${resultfile}.jiracli"
             status=${PIPESTATUS[0]}
             set -e

--- a/tracker_automations/bulk_precheck_issues/criteria/awaiting_integration/override-defaults.sh
+++ b/tracker_automations/bulk_precheck_issues/criteria/awaiting_integration/override-defaults.sh
@@ -1,4 +1,10 @@
-# Alows the following options to be overridden:
-# $maxcommits: Max number of commits accepted per run. Error if exceeded. Defaults to 100.
+# Allows awaiting_integration criteria options to be customized.
 
-maxcommits=15
+# Note the following is just a (disabled) example about how the
+# bulk_checker variables can be customized by criteria, enabling
+# different behaviors for different types of execution. This can
+# be used to support different checks/plans by criteria or any
+# other customization requiring custom handling.
+
+# Max number of commits accepted per run. Error if exceeded. Defaults to 100. We want to reduce them for this criteria.
+# maxcommitserror=15


### PR DESCRIPTION
To better support branches with a number of commits, the old, unique,
maxcommits setting is changed plugin-wide to use a couple of settings
instead.

Also, we are moving from an eroor&stop behavior (where the rest of the
checks were not applied) to a error/warn and continue behavior, by
showing the maxcommits warnings and errors within the commits checker.

This may lead to problems is somebody does submit a huge/wrong branch,
but that also was happening right now irrespectively of the # of
commits. If we need countermeasures for that situation, time will tell.