### PR TITLE
MDLSIT-2417 ant: Fix PHP Lint issues

### DIFF
--- a/generate_component_ant_files/generate_component_ant_files.php
+++ b/generate_component_ant_files/generate_component_ant_files.php
@@ -75,7 +75,7 @@ if (!is_writable($options['basedir'])) {
     cli_error('Non-writable directory: ' . $options['basedir']);
 }
 
- Get all the plugin and subplugin types
+// Get all the plugin and subplugin types
 $types = get_plugin_types(false);
 // For each type, get their available implementations
 foreach ($types as $type => $typerelpath) {


### PR DESCRIPTION
Discovered because our Travis now tries to run all files if it could not
determine the correct files changed. This causes a failure in this situation.