### PR TITLE
MDLSITE-3667 commits: Improve handling of additional ':' it message

### DIFF
--- a/verify_commit_messages/verify_commit_messages.sh
+++ b/verify_commit_messages/verify_commit_messages.sh
@@ -153,8 +153,15 @@ for c in ${commits}; do
                         numproblems=$((numproblems+1))
                     fi
                 fi
-                # verify there is an area after the issue code, ending in :. Warn.
+
                 if [[ ! ${missingissuecode} ]]; then
+                    # Verify there are not superfolous characters between the issuecode and codearea.
+                    if [[ ! "${line}" =~ ^${templateissuecode}:?\ *[A-Za-z] ]]; then
+                        echo "${c}*warning*The commit does not match expected format '${issuecode} codearea: message'."
+                        numproblems=$((numproblems+1))
+                    fi
+
+                    # verify there is an area after the issue code, ending in :. Warn.
                     if [[ ! "${line}" =~ ^${templateissuecode}:?\ ([^:]*):\  ]];then
                         echo "${c}*warning*The commit does not define a code area ending with a colon and a space after the issue code."
                         numproblems=$((numproblems+1))

--- a/verify_commit_messages/verify_commit_messages.sh
+++ b/verify_commit_messages/verify_commit_messages.sh
@@ -135,7 +135,7 @@ for c in ${commits}; do
             if [[ ${currentline} -eq 1 ]]; then
                 # verify subject begins with template issue code + space. Error.
                 if [[ ! "${line}" =~ ^${templateissuecode}:?\  ]];then
-                    echo "${c}*error*The commit does not begin with the expected issue code ${templateissuecode} and a space."
+                    echo "${c}*error*The commit message does not begin with the expected issue code ${templateissuecode} and a space."
                     numproblems=$((numproblems+1))
                     missingissuecode=1
                 fi
@@ -144,11 +144,11 @@ for c in ${commits}; do
                     if [[ ! "${line}" =~ ^${issuecode}\  ]]; then
                         # If the issue code in anywhere else in the message relax it a bit. Warning. Else Error.
                         if [[ "${message}" =~ ${issuecode}\  ]]; then
-                            echo "${c}*warning*The commit contains the expected issue code ${issuecode} but in wrong place. That is allowed only for epics or issues with subtasks. Verify it."
+                            echo "${c}*warning*The commit message contains the expected issue code ${issuecode} but in wrong place. That is allowed only for epics or issues with subtasks. Verify it."
                         elif [[ "${line}" =~ ^${issuecode}:\  ]]; then
-                            echo "${c}*warning*The commit contains ${issuecode} followed by a colon. The expected format is '${issuecode} codearea: message'"
+                            echo "${c}*warning*The commit message contains ${issuecode} followed by a colon. The expected format is '${issuecode} codearea: message'"
                         else
-                            echo "${c}*error*The commit does not contain the expected issue code ${issuecode} and a space."
+                            echo "${c}*error*The commit message does not contain the expected issue code ${issuecode} and a space."
                         fi
                         numproblems=$((numproblems+1))
                     fi
@@ -157,13 +157,13 @@ for c in ${commits}; do
                 if [[ ! ${missingissuecode} ]]; then
                     # Verify there are not superfolous characters between the issuecode and codearea.
                     if [[ ! "${line}" =~ ^${templateissuecode}:?\ *[A-Za-z] ]]; then
-                        echo "${c}*warning*The commit does not match expected format '${issuecode} codearea: message'."
+                        echo "${c}*warning*The commit message does not match expected format '${issuecode} codearea: message'."
                         numproblems=$((numproblems+1))
                     fi
 
                     # verify there is an area after the issue code, ending in :. Warn.
                     if [[ ! "${line}" =~ ^${templateissuecode}:?\ ([^:]*):\  ]];then
-                        echo "${c}*warning*The commit does not define a code area ending with a colon and a space after the issue code."
+                        echo "${c}*warning*The commit message does not define a code area ending with a colon and a space after the issue code."
                         numproblems=$((numproblems+1))
                     else
                         codearea=${BASH_REMATCH[1]}
@@ -173,7 +173,7 @@ for c in ${commits}; do
                 if [[ ${codearea} ]]; then
                     codearealen=$(echo "${codearea}" | wc -c)
                     if [[ ${codearealen} -gt 30 ]];then
-                        echo "${c}*warning*The commit code area '${codearea}' is too long (${codearealen} > 30)"
+                        echo "${c}*warning*The commit message code area '${codearea}' is too long (${codearealen} > 30)"
                         numproblems=$((numproblems+1))
                     fi
                 fi

--- a/verify_commit_messages/verify_commit_messages.sh
+++ b/verify_commit_messages/verify_commit_messages.sh
@@ -134,7 +134,7 @@ for c in ${commits}; do
             # check 1st line
             if [[ ${currentline} -eq 1 ]]; then
                 # verify subject begins with template issue code + space. Error.
-                if [[ ! "${line}" =~ ^${templateissuecode}\  ]];then
+                if [[ ! "${line}" =~ ^${templateissuecode}:?\  ]];then
                     echo "${c}*error*The commit does not begin with the expected issue code ${templateissuecode} and a space."
                     numproblems=$((numproblems+1))
                     missingissuecode=1
@@ -145,6 +145,8 @@ for c in ${commits}; do
                         # If the issue code in anywhere else in the message relax it a bit. Warning. Else Error.
                         if [[ "${message}" =~ ${issuecode}\  ]]; then
                             echo "${c}*warning*The commit contains the expected issue code ${issuecode} but in wrong place. That is allowed only for epics or issues with subtasks. Verify it."
+                        elif [[ "${line}" =~ ^${issuecode}:\  ]]; then
+                            echo "${c}*warning*The commit contains ${issuecode} followed by a colon. The expected format is '${issuecode} codearea: message'"
                         else
                             echo "${c}*error*The commit does not contain the expected issue code ${issuecode} and a space."
                         fi
@@ -153,7 +155,7 @@ for c in ${commits}; do
                 fi
                 # verify there is an area after the issue code, ending in :. Warn.
                 if [[ ! ${missingissuecode} ]]; then
-                    if [[ ! "${line}" =~ ^${templateissuecode}\ ([^:]*):\  ]];then
+                    if [[ ! "${line}" =~ ^${templateissuecode}:?\ ([^:]*):\  ]];then
                         echo "${c}*warning*The commit does not define a code area ending with a colon and a space after the issue code."
                         numproblems=$((numproblems+1))
                     else


### PR DESCRIPTION
1) Clarify the `MDL-1234: foo: case`
2) Throw warning on previously undetected `MDL-1234 - foo: case`
3) Clarify language to say its commit message, not commit, as suggested by @mudrd8mz 

Can be tested with my moodle branch: 

```
git://github.com/danpoltawski/moodle.git MDLSITE-3667-horrible-commits
```

Previously reported errors:
```
------------------------------
commit: f353267, message:
MDL-12345 ok: message is ok

Results:
Ok
------------------------------
commit: 0341e65, message:
MDL-12345-forum: test

Results:
0341e65*error*The commit does not begin with the expected issue code MDL-[0-9]{3,6} and a space.
0341e65*error*The commit does not contain the expected issue code MDL-12345 and a space.
(found 2 problems)
------------------------------
commit: 902a90d, message:
MDL-12345 foo - bar baz

Results:
902a90d*warning*The commit does not define a code area ending with a colon and a space after the issue code.
(found 1 problems)
------------------------------
commit: 8e7911c, message:
MDL-12345 - foo: bar baz

Results:
Ok
------------------------------
commit: 506ab3b, message:
MDL-12345: foo: bar baz

Results:
506ab3b*error*The commit does not begin with the expected issue code MDL-[0-9]{3,6} and a space.
506ab3b*error*The commit does not contain the expected issue code MDL-12345 and a space.
(found 2 problems)

Total number of problems found: 5 (used as exit code).
```


Now:

```
------------------------------
commit: f353267, message:
MDL-12345 ok: message is ok

Results:
Ok
------------------------------
commit: 0341e65, message:
MDL-12345-forum: test

Results:
0341e65*error*The commit message does not begin with the expected issue code MDL-[0-9]{3,6} and a space.
0341e65*error*The commit message does not contain the expected issue code MDL-12345 and a space.
(found 2 problems)
------------------------------
commit: 902a90d, message:
MDL-12345 foo - bar baz

Results:
902a90d*warning*The commit message does not define a code area ending with a colon and a space after the issue code.
(found 1 problems)
------------------------------
commit: 8e7911c, message:
MDL-12345 - foo: bar baz

Results:
8e7911c*warning*The commit message does not match expected format 'MDL-12345 codearea: message'.
(found 1 problems)
------------------------------
commit: 506ab3b, message:
MDL-12345: foo: bar baz

Results:
506ab3b*warning*The commit message contains MDL-12345 followed by a colon. The expected format is 'MDL-12345 codearea: message'
(found 1 problems)

Total number of problems found: 5 (used as exit code).
```