### PR TITLE
MDLSITE-3701 tracker: query issues 'peer review in progress' for checks

### DIFF
--- a/tracker_automations/bulk_precheck_issues/criteria/awaiting_peer_review/query.sh
+++ b/tracker_automations/bulk_precheck_issues/criteria/awaiting_peer_review/query.sh
@@ -1,6 +1,6 @@
 ${basereq} --action getIssueList \
            --search "project = 'Moodle' \
-                 AND status = 'Waiting for peer review' \
+                 AND (status = 'Waiting for peer review' OR status = 'Peer review in progress') \
                  AND (labels IS EMPTY OR labels NOT IN (ci, security_held, integration_held)) \
                  AND level IS EMPTY \
                  ORDER BY priority DESC, votes DESC, 'Last comment date' ASC" \


### PR DESCRIPTION
If issues are peer reviewed too quickly, they do not get the ci label. 


*note* I haven't tested this yet ;-)