### PR TITLE
Use HTTPS for smileys when possible

### DIFF
--- a/tracker_automations/bulk_precheck_issues/util.sh
+++ b/tracker_automations/bulk_precheck_issues/util.sh
@@ -29,22 +29,20 @@ function negative_tracker_emoticon() {
 
 
 function get_happy_image() {
-    # marys pompoms:
-    images[0]='http://bylazydaisy.co.uk/AnimatedAmy.gif'
     # balloon🎈
-    images[1]='http://twemoji.maxcdn.com/16x16/1f388.png'
+    images[0]='//twemoji.maxcdn.com/16x16/1f388.png'
     # party popper 🎉
-    images[2]='http://twemoji.maxcdn.com/16x16/1f389.png'
+    images[1]='//twemoji.maxcdn.com/16x16/1f389.png'
     # clinking beer mugs 🍻
-    images[3]='http://twemoji.maxcdn.com/16x16/1f37b.png'
+    images[2]='//twemoji.maxcdn.com/16x16/1f37b.png'
     # cookie 🍪
-    images[4]='http://twemoji.maxcdn.com/16x16/1f36a.png'
+    images[3]='//twemoji.maxcdn.com/16x16/1f36a.png'
     # cake 🍰
-    images[5]='http://twemoji.maxcdn.com/16x16/1f370.png'
+    images[4]='//twemoji.maxcdn.com/16x16/1f370.png'
     # glowing star 🌟
-    images[6]='http://twemoji.maxcdn.com/16x16/1f31f.png'
+    images[5]='//twemoji.maxcdn.com/16x16/1f31f.png'
     # smiling face with halo 😇
-    images[7]='http://twemoji.maxcdn.com/16x16/1f607.png'
+    images[6]='//twemoji.maxcdn.com/16x16/1f607.png'
 
     index=$[$RANDOM % ${#images[@]}]
     echo ${images[$index]}
@@ -52,21 +50,21 @@ function get_happy_image() {
 
 function get_sad_image() {
     # fire 🔥
-    images[0]='http://twemoji.maxcdn.com/16x16/1f525.png'
+    images[0]='//twemoji.maxcdn.com/16x16/1f525.png'
     # pile of poo 💩
-    images[1]='http://twemoji.maxcdn.com/16x16/1f4a9.png'
+    images[1]='//twemoji.maxcdn.com/16x16/1f4a9.png'
     # speak-no-evil monkey 🙊
-    images[2]='http://twemoji.maxcdn.com/16x16/1f64a.png'
+    images[2]='//twemoji.maxcdn.com/16x16/1f64a.png'
     # bug 🐜
-    images[3]='http://twemoji.maxcdn.com/16x16/1f41c.png'
+    images[3]='//twemoji.maxcdn.com/16x16/1f41c.png'
     # face screaming in fear 😱
-    images[4]='http://twemoji.maxcdn.com/16x16/1f631.png'
+    images[4]='//twemoji.maxcdn.com/16x16/1f631.png'
     # construction sign 🚧
-    images[5]='http://twemoji.maxcdn.com/16x16/1f6a7.png'
+    images[5]='//twemoji.maxcdn.com/16x16/1f6a7.png'
     # sos 🆘
-    images[6]='http://twemoji.maxcdn.com/16x16/1f198.png'
+    images[6]='//twemoji.maxcdn.com/16x16/1f198.png'
     # skull 💀
-    images[7]='http://twemoji.maxcdn.com/16x16/1f480.png'
+    images[7]='//twemoji.maxcdn.com/16x16/1f480.png'
 
     index=$[$RANDOM % ${#images[@]}]
     echo ${images[$index]}


### PR DESCRIPTION
Using HTTP breaks the HTTPS validation on the tracker. I removed the pom pom girl as it doesn't have an HTTPS equivalent.

Note: Untested.