### PR TITLE
MDLSITE-3818 cleanup: kill BUILD_ID and delete issues details

### DIFF
--- a/detect_conflicts/detect_conflicts.sh
+++ b/detect_conflicts/detect_conflicts.sh
@@ -4,6 +4,7 @@
 
 # calculate some variables
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BUILD_TIMESTAMP="$(date +'%Y-%m-%d_%H-%M-%S')"
 
 # dirs and files (egrep-like regexp) we are going to exclude from analysis
 exclude="/.git"
@@ -44,14 +45,14 @@ fi
 
 # Count and send to countfile
 count=`cat "$lastfile" | wc -l`
-echo "$BUILD_NUMBER	$BUILD_ID	$count" >> "$countfile"
+echo "$BUILD_NUMBER	$BUILD_TIMESTAMP	$count" >> "$countfile"
 
 # Get best count ever or create it
 bestcount=999999
 if [[ ! -f "$mincountfile" ]]
 then
     # Create the file (first run) with current counter
-    echo "$BUILD_NUMBER	$BUILD_ID	$bestcount" > "$mincountfile"
+    echo "$BUILD_NUMBER	$BUILD_TIMESTAMP	$bestcount" > "$mincountfile"
 else
     # Read the best counter
     bestcount=`tail -1 "$mincountfile" | cut -s -f3`
@@ -77,7 +78,7 @@ else
     then
         # Best ever, save current counter as best, grab correctfile and delete diff
         echo "got best results ever, yay!"
-        echo "$BUILD_NUMBER	$BUILD_ID	$count" > "$mincountfile"
+        echo "$BUILD_NUMBER	$BUILD_TIMESTAMP	$count" > "$mincountfile"
         cp "$lastfile" "$correctfile"
         rm -fr "$difffile"
         status=0

--- a/illegal_whitespace/illegal_whitespace.sh
+++ b/illegal_whitespace/illegal_whitespace.sh
@@ -4,6 +4,7 @@
 
 # calculate some variables
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BUILD_TIMESTAMP="$(date +'%Y-%m-%d_%H-%M-%S')"
 
 # dirs and files (egrep-like regexp) we are going to exclude from analysis
 . ${mydir}/../define_excluded/define_excluded.sh
@@ -43,14 +44,14 @@ fi
 
 # Count and send to countfile
 count=`cat "$lastfile" | wc -l`
-echo "$BUILD_NUMBER	$BUILD_ID	$count" >> "$countfile"
+echo "$BUILD_NUMBER	$BUILD_TIMESTAMP	$count" >> "$countfile"
 
 # Get best count ever or create it
 bestcount=999999
 if [[ ! -f "$mincountfile" ]]
 then
     # Create the file (first run) with current counter
-    echo "$BUILD_NUMBER	$BUILD_ID	$bestcount" > "$mincountfile"
+    echo "$BUILD_NUMBER	$BUILD_TIMESTAMP	$bestcount" > "$mincountfile"
 else
     # Read the best counter
     bestcount=`tail -1 "$mincountfile" | cut -s -f3`
@@ -76,7 +77,7 @@ else
     then
         # Best ever, save current counter as best, grab correctfile and delete diff
         echo "got best results ever, yay!"
-        echo "$BUILD_NUMBER	$BUILD_ID	$count" > "$mincountfile"
+        echo "$BUILD_NUMBER	$BUILD_TIMESTAMP	$count" > "$mincountfile"
         cp "$lastfile" "$correctfile"
         rm -fr "$difffile"
         status=0

--- a/tracker_automations/move_to_current_integration/move_to_current_integration.sh
+++ b/tracker_automations/move_to_current_integration/move_to_current_integration.sh
@@ -32,6 +32,7 @@ logfile=$WORKSPACE/move_to_current_integration.log
 # Calculate some variables
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 basereq="${jiraclicmd} --server ${jiraserver} --user ${jirauser} --password ${jirapass}"
+BUILD_TIMESTAMP="$(date +'%Y-%m-%d_%H-%M-%S')"
 
 # Note this could be done by one unique "runFromIssueList" action, but we are splitting
 # the search and the update in order to log all the reopenend issues within jenkins ($logfile)
@@ -66,5 +67,8 @@ for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
     ${basereq} --action removeLabels \
         --issue ${issue} \
         --labels "ci"
-    echo "$BUILD_NUMBER $BUILD_ID ${issue}" >> "${logfile}"
+    echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue}" >> "${logfile}"
 done
+
+# Remove the resultfile. We don't want to disclose those details.
+rm -fr "${resultfile}"

--- a/tracker_automations/mv_reopened_out_from_current/mv_reopened_out_from_current.sh
+++ b/tracker_automations/mv_reopened_out_from_current/mv_reopened_out_from_current.sh
@@ -27,6 +27,7 @@ logfile=$WORKSPACE/mv_reopened_out_from_current.log
 # Calculate some variables
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 basereq="${jiraclicmd} --server ${jiraserver} --user ${jirauser} --password ${jirapass}"
+BUILD_TIMESTAMP="$(date +'%Y-%m-%d_%H-%M-%S')"
 
 # Note this could be done by one unique "runFromIssueList" action, but we are splitting
 # the search and the update in order to log all the reopenend issues within jenkins ($logfile)
@@ -60,5 +61,8 @@ for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
         --fixVersions "" \
         --custom "customfield_10211:" \
         --comment "Moving this reopened issue out from current integration. Please, re-submit it for integration once ready."
-    echo "$BUILD_NUMBER $BUILD_ID ${issue}" >> "${logfile}"
+    echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue}" >> "${logfile}"
 done
+
+# Remove the resultfile. We don't want to disclose those details.
+rm -fr "${resultfile}"

--- a/tracker_automations/remove_ci_label_from_wip/remove_ci_label_from_wip.sh
+++ b/tracker_automations/remove_ci_label_from_wip/remove_ci_label_from_wip.sh
@@ -27,6 +27,7 @@ logfile=$WORKSPACE/remove_ci_label_from_wip.log
 # Calculate some variables
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 basereq="${jiraclicmd} --server ${jiraserver} --user ${jirauser} --password ${jirapass}"
+BUILD_TIMESTAMP="$(date +'%Y-%m-%d_%H-%M-%S')"
 
 # Note this could be done by one unique "runFromIssueList" action, but we are splitting
 # the search and the update in order to log all the reopenend issues within jenkins ($logfile)
@@ -44,5 +45,8 @@ for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
     ${basereq} --action removeLabels \
         --issue ${issue} \
          --labels "ci"
-    echo "$BUILD_NUMBER $BUILD_ID ${issue}" >> "${logfile}"
+    echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue}" >> "${logfile}"
 done
+
+# Remove the resultfile. We don't want to disclose those details.
+rm -fr "${resultfile}"


### PR DESCRIPTION
This commit cleans all remaining jobs using BUILD_ID and, instead
do use a calculated (now), BUILD_TIMESTAMP, that is what BUILD_ID
used to contain. Note this is basically a cosmetic change to make
scripts to show information as it was some time ago.

Also, in various tracker jobs where a number of issues (with full
details) are returned, to avoid any disclosure of (security...)
information, the file where details are stored is explicitly
deleted at the end of the process.