### PR TITLE
MDLSITE-4358 unit tests: move away from template1 as dflt. database

### DIFF
--- a/run_phpunittests/run_phpunittests.sh
+++ b/run_phpunittests/run_phpunittests.sh
@@ -35,7 +35,7 @@ datadirphpunit=/tmp/ci_dataroot_phpunit_${BUILD_NUMBER}_${EXECUTOR_NUMBER}
 # Based on $dbtype, execute different DB creation commands (mysqli, pgsql)
 if [[ "${dbtype}" == "pgsql" ]]; then
     export PGPASSWORD=${dbpass}
-    ${psqlcmd} -h ${dbhost} -U ${dbuser} -d template1 \
+    ${psqlcmd} -h ${dbhost} -U ${dbuser} -d postgres \
         -c "CREATE DATABASE ${installdb} ENCODING 'utf8'"
 elif [[ "${dbtype}" == "mysqli" ]]; then
     ${mysqlcmd} --user=${dbuser} --password=${dbpass} --host=${dbhost} \
@@ -205,7 +205,7 @@ fi
 # Based on $dbtype, execute different DB deletion commands (pgsql, mysqli)
 if [[ "${dbtype}" == "pgsql" ]]; then
     export PGPASSWORD=${dbpass}
-    ${psqlcmd} -h ${dbhost} -U ${dbuser} -d template1 \
+    ${psqlcmd} -h ${dbhost} -U ${dbuser} -d postgres \
         -c "DROP DATABASE ${installdb}"
 elif [[ "${dbtype}" == "mysqli" ]]; then
     ${mysqlcmd} --user=${dbuser} --password=${dbpass} --host=${dbhost} \


### PR DESCRIPTION
This avoid concurrence problems when 2 jobs are trying to issue
create database statements, rare because it's quick command (1s)
but possible (we have experimented it).