### PR TITLE
MDLSITE-4366 savepoints: discard unsafe strings to avoid problems

### DIFF
--- a/check_upgrade_savepoints/check_upgrade_savepoints.sh
+++ b/check_upgrade_savepoints/check_upgrade_savepoints.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
+# $WORKSPACE
 # $phpcmd: Path to the PHP CLI executable
 # $gitdir: Directory containing git repo
 # $gitbranch: Branch we are going to check
 
 # Let's go strict (exit on error)
 set -e
+
+# Verify everything is set
+required="WORKSPACE phpcmd gitdir gitbranch"
+for var in $required; do
+    if [ -z "${!var}" ]; then
+        echo "Error: ${var} environment variable is not defined. See the script comments."
+        exit 1
+    fi
+done
 
 # file where results will be sent
 resultfile=$WORKSPACE/check_upgrade_savepoints_${gitbranch}.txt


### PR DESCRIPTION
Now we pre-process the upgrade code, looking for all strings
within it. If the string is considered dangerous (contains
parenthesis and other chars, then it's replaced by safe placeholder
so next regexp operations won't fail).

Safe strings are kept in place in order to keep code transformations
being as small as possible, in case we want to add more checks in
the future (savepoint params checks...).