### PR TITLE
Check shifter lint errors in the prechecker

### DIFF
--- a/grunt_process/grunt_process.sh
+++ b/grunt_process/grunt_process.sh
@@ -69,7 +69,8 @@ cd ${gitdir}
 rm -fr $(find . -path '*/yui/build' -type d)
 rm -fr $(find . -path '*/amd/build' -type d)
 
-${gitdir}/node_modules/grunt-cli/bin/grunt --no-color | tee "${outputfile}"
+# The echo here works around a problem where shifter is sending colours (MDL-52591).
+echo | ${gitdir}/node_modules/grunt-cli/bin/grunt --no-color | tee "${outputfile}"
 exitstatus=${PIPESTATUS[0]}
 
 # Cleanup symlink as not required after run (and prevent other jobs operating on it)

--- a/remote_branch_checker/checkstyle_converter.php
+++ b/remote_branch_checker/checkstyle_converter.php
@@ -44,7 +44,7 @@ if ($unrecognized) {
     cli_error(get_string('cliunknowoption', 'admin', $unrecognized));
 }
 
-$validformats = array('phplint', 'thirdparty', 'gruntdiff');
+$validformats = array('phplint', 'thirdparty', 'gruntdiff', 'shifter');
 
 
     $help =
@@ -171,6 +171,31 @@ function process_thirdparty($line) {
 
         $output.= '<file name="' . $filename. '">'.PHP_EOL;
         $output.= '<error line="'.$lineno.'" column="0" severity="warning" ';
+        $output.= 'message="' .s($message). ' "/>' . PHP_EOL;
+        $output.= '</file>';
+    }
+
+    return $output;
+}
+
+/**
+ * Converts shifter output into checkstyle format
+ *
+ * Example input:
+ *   shifter [err] /path/to/lib/editor/atto/plugins/rtl/yui/src/button/js/button.js contains 2 lint errors
+ *
+ * @param string $line the line of file
+ * @return string the xml fragment
+ */
+function process_shifter($line) {
+    $output = '';
+    if (preg_match('/shifter \[err\] (\S+) (.*)/', $line, $matches)) {
+        $filename = $matches[1];
+        $message = $matches[2];
+        $lineno = 0;
+
+        $output.= '<file name="' . $filename. '">'.PHP_EOL;
+        $output.= '<error line="'.$lineno.'" column="0" severity="error" ';
         $output.= 'message="' .s($message). ' "/>' . PHP_EOL;
         $output.= '</file>';
     }

--- a/remote_branch_checker/lib.php
+++ b/remote_branch_checker/lib.php
@@ -206,6 +206,23 @@ class remote_branch_reporter {
             }
         }
 
+        // Process the shifter output, weighting errors with 5 and warnings with 1
+        $params = array(
+            'title' => 'shifter problems',
+            'abbr' => 'shifter',
+            'description' => 'This section shows problems detected by shifter',
+            'url' => 'https://docs.moodle.org/dev/YUI/Shifter',
+            'codedir' => dirname($this->directory) . '/',
+            'errorweight' => 5,
+            'warningweight' => 1,
+            'allowfiltering' => 1);
+        if ($node = $this->apply_xslt($params, $this->directory . '/shifter.xml', 'checkstyle2smurf.xsl')) {
+            if ($check = $node->getElementsByTagName('check')->item(0)) {
+                $snode = $doc->importNode($check, true);
+                $smurf->appendChild($snode);
+            }
+        }
+
         // Conditionally, perform the filtering
         if ($patchset) {
             $this->patchset_filter($doc, $patchset);

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -339,8 +339,9 @@ cat "${WORKSPACE}/work/thirdparty.txt" | ${phpcmd} ${mydir}/checkstyle_converter
 # Run the grunt checker if Gruntfile exists.
 if [ -f ${WORKSPACE}/Gruntfile.js ]; then
     echo "Running grunt.."
-    ${mydir}/../grunt_process/grunt_process.sh > "${WORKSPACE}/work/grunt.txt"
+    ${mydir}/../grunt_process/grunt_process.sh > "${WORKSPACE}/work/grunt.txt" 2> "${WORKSPACE}/work/grunt-errors.txt"
     cat "${WORKSPACE}/work/grunt.txt" | ${phpcmd} ${mydir}/checkstyle_converter.php --format=gruntdiff > "${WORKSPACE}/work/grunt.xml"
+    cat "${WORKSPACE}/work/grunt-errors.txt" | ${phpcmd} ${mydir}/checkstyle_converter.php --format=shifter > "${WORKSPACE}/work/shifter.xml"
 fi
 
 


### PR DESCRIPTION
Can be tested with, for example of problem output:
```git://github.com/danpoltawski/moodle.git shifter-lint-prob```

And when fixed:
```git://github.com/danpoltawski/moodle.git shifter-lint-ok```