### PR TITLE
Change the php code sniffer abbreviation

### DIFF
--- a/remote_branch_checker/lib.php
+++ b/remote_branch_checker/lib.php
@@ -79,7 +79,7 @@ class remote_branch_reporter {
         // Process the cs output, weighting errors with 5 and warnings with 1
         $params = array(
             'title' => 'PHP coding style problems',
-            'abbr' => 'php',
+            'abbr' => 'phpcs',
             'description' => 'This section shows the coding style problems detected in the code by phpcs',
             'url' => 'http://docs.moodle.org/dev/Coding_style',
             'codedir' => dirname($this->directory) . '/',


### PR DESCRIPTION
When I see the output of a smurf report with php coding style
problems, I frequently mistake it for the phplint check - which is
much more serious problem.

To avoid this confusion I propose to change the shortname to phpcs to
make it clearer.

An example of me dong this was for [this issue](https://tracker.moodle.org/browse/MDL-39913?focusedCommentId=393168&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-393168).