### PR TITLE
MDLSITE-4415 CiBoT: exclude info lines from jira report

### DIFF
--- a/tracker_automations/bulk_precheck_issues/bulk_precheck_issues.sh
+++ b/tracker_automations/bulk_precheck_issues/bulk_precheck_issues.sh
@@ -239,8 +239,8 @@ while read issue; do
                 set -e
                 # Look if the file contains some controlled error.
                 if [[ ${curlstatus} -eq 0 ]] && [[ -n $(echo "${errors}" | grep "Error:") ]]; then
-                    # controlled errors, print them.
-                    perrors=$(echo "${errors}" | sed 's/^/    -- /g')
+                    # controlled errors, print them. (exclude info lines, see MDLSITE-4415)
+                    perrors=$(echo "${errors}" | grep -v '^Info:' | sed 's/^/    -- /g')
                     echo "${perrors}" | tee -a "${resultfile}.${issue}.txt"
                 else
                     # Failed prechecker and nothing reported via errors, generic error message


### PR DESCRIPTION
Just skipping all the Info: lines reported by the prechecker should be enough, only showing the real error ones we are interested to show.