### PR TITLE
NOBUG: Centralize all the npm install stuff

### DIFF
--- a/prepare_npm_stuff/prepare_npm_stuff.sh
+++ b/prepare_npm_stuff/prepare_npm_stuff.sh
@@ -68,16 +68,10 @@ if [[ -f ${gitdir}/package.json ]]; then
 
     # Always run npm install to keep our npm packages correct
     ${npmcmd} --no-color install
-    exitstatus=${PIPESTATUS[0]}
-    if [[ ${exitstatus} -ne 0 ]]; then
-        echo "ERROR: Problems installing npm stuff"
-        exit $exitstatus
-    fi
-fi
+else
 
-# Install shifter version if there is not package.json and shifter version has been specified
-# (this is required for branches < 29_STABLE)
-if [[ ! -f ${gitdir}/package.json ]] && [[ -n ${shifterversion} ]]; then
+    # Install shifter version if there is not package.json
+    # (this is required for branches < 29_STABLE)
     shifterinstall=""
     shiftercmd="$(${npmcmd} bin)"/shifter
     if [[ ! -f ${shiftercmd} ]]; then
@@ -98,17 +92,10 @@ if [[ ! -f ${gitdir}/package.json ]] && [[ -n ${shifterversion} ]]; then
     if [[ -n ${shifterinstall} ]]; then
         ${npmcmd} --no-color install shifter@${shifterversion}
         echo "INFO: shifter executable (${shifterversion}) installed"
-        exitstatus=${PIPESTATUS[0]}
-        if [[ ${exitstatus} -ne 0 ]]; then
-            echo "ERROR: Problems installing shifter ${shifterversion}"
-            exit $exitstatus
-        fi
     fi
-fi
 
-# Install recess version if there is not package.json and recess version has been specified
-# (this is required for branches < 29_STABLE)
-if [[ ! -f ${gitdir}/package.json ]] && [[ -n ${recessversion} ]]; then
+    # Install recess version if there is not package.json
+    # (this is required for branches < 29_STABLE)
     recessinstall=""
     recesscmd="$(${npmcmd} bin)"/recess
     if [[ ! -f ${recesscmd} ]]; then
@@ -128,11 +115,6 @@ if [[ ! -f ${gitdir}/package.json ]] && [[ -n ${recessversion} ]]; then
     if [[ -n ${recessinstall} ]]; then
         ${npmcmd} --no-color install recess@${recessversion}
         echo "INFO: recess executable (${recessversion}) installed"
-        exitstatus=${PIPESTATUS[0]}
-        if [[ ${exitstatus} -ne 0 ]]; then
-            echo "ERROR: Problems installing recess ${recessversion}"
-            exit $exitstatus
-        fi
     fi
 fi
 

--- a/prepare_npm_stuff/prepare_npm_stuff.sh
+++ b/prepare_npm_stuff/prepare_npm_stuff.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# $gitdir: Directory containing git repo
+# $gitbranch: Branch we are going to install the DB
+# $extrapath: Extra paths to be available (global)
+# $npmcmd: Path to the npm executable (global)
+# $npmbase: Base directory where we'll store multiple npm packages versions (subdirectories per branch)
+# $shifterversion: Optional, defaults to 0.4.6. Not installed if there is a package.json file (present in 29 and up)
+# $recessversion: Optional, defaults to 1.1.6. Not installed if there is a package.json file (present in 29 and up)
+
+# Let's be strict. Any problem leads to failure.
+set -e
+
+required="gitdir gitbranch extrapath npmcmd npmbase"
+for var in $required; do
+    if [ -z "${!var}" ]; then
+        echo "ERROR: ${var} environment variable is not defined. See the script comments."
+        exit 1
+    fi
+done
+
+# calculate some variables
+mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Let add $extrapath to PATH
+if [[ -n ${extrapath} ]]; then
+    export PATH=${PATH}:${extrapath}
+fi
+
+# Apply some defaults.
+shifterversion=${shifterversion:-0.4.6}
+recessversion=${recessversion:-1.1.6}
+
+# Move to base directory
+cd ${gitdir}
+
+# Verify we have the npmbase dir, creating if needed
+if [[ ! -d ${npmbase} ]]; then
+    echo "WARN: npmbase dir (${npmbase}) not found. Creating it"
+    mkdir -p ${npmbase}
+    echo "INFO: npmbase dir (${npmbase}) created"
+else
+    echo "OK: npmbase dir (${npmbase}) found"
+fi
+
+# Verify we have already the gitbranch dir, creating if needed
+if [[ ! -d ${npmbase}/${gitbranch}/node_modules ]]; then
+    echo "WARN: npmbase for branch (${gitbranch}) not found. Creating it"
+    mkdir -p ${npmbase}/${gitbranch}/node_modules
+    echo "INFO: npmbase for branch (${gitbranch}) created"
+else
+    echo "OK: npmbase for branch (${gitbranch}) found"
+fi
+
+# Linking it (after removing, just in case)
+echo "INFO: Linking ${npmbase}/${gitbranch}/node_modules to ${gitdir}/node_modules"
+ln -nfs ${npmbase}/${gitbranch}/node_modules ${gitdir}/node_modules
+
+# Install general stuff only if there is a package.json file
+if [[ -f ${gitdir}/package.json ]]; then
+    echo "INFO: Installing npm stuff following package/shrinkwrap details"
+
+    # Verify there is a grunt executable available, installing if missing
+    gruntcmd="$(${npmcmd} bin)"/grunt
+    if [[ ! -f ${gruntcmd} ]]; then
+        echo "WARN: grunt-cli executable not found. Installing everything"
+        ${npmcmd} install --no-color grunt-cli
+    fi
+
+    # Always run npm install to keep our npm packages correct
+    ${npmcmd} --no-color install
+    exitstatus=${PIPESTATUS[0]}
+    if [[ ${exitstatus} -ne 0 ]]; then
+        echo "ERROR: Problems installing npm stuff"
+        exit $exitstatus
+    fi
+fi
+
+# Install shifter version if there is not package.json and shifter version has been specified
+# (this is required for branches < 29_STABLE)
+if [[ ! -f ${gitdir}/package.json ]] && [[ -n ${shifterversion} ]]; then
+    shifterinstall=""
+    shiftercmd="$(${npmcmd} bin)"/shifter
+    if [[ ! -f ${shiftercmd} ]]; then
+        echo "WARN: shifter executable not found. Installing it"
+        shifterinstall=1
+    else
+        # Have shifter, look its version matches expected one
+        # Cannot use --version because it's varying (performing calls to verify latest). Use --help instead
+        shiftercurrent=$(${shiftercmd} --no-color --help | head -1 | cut -d "@" -f2)
+        if [[ "${shiftercurrent}" != "${shifterversion}" ]]; then
+            echo "WARN: shifter executable "${shiftercurrent}" found, "${shifterversion}" expected. Installing it"
+            shifterinstall=1
+        else
+            # All right, shifter found and version matches
+            echo "INFO: shifter executable (${shifterversion}) found"
+        fi
+    fi
+    if [[ -n ${shifterinstall} ]]; then
+        ${npmcmd} --no-color install shifter@${shifterversion}
+        echo "INFO: shifter executable (${shifterversion}) installed"
+        exitstatus=${PIPESTATUS[0]}
+        if [[ ${exitstatus} -ne 0 ]]; then
+            echo "ERROR: Problems installing shifter ${shifterversion}"
+            exit $exitstatus
+        fi
+    fi
+fi
+
+# Install recess version if there is not package.json and recess version has been specified
+# (this is required for branches < 29_STABLE)
+if [[ ! -f ${gitdir}/package.json ]] && [[ -n ${recessversion} ]]; then
+    recessinstall=""
+    recesscmd="$(${npmcmd} bin)"/recess
+    if [[ ! -f ${recesscmd} ]]; then
+        echo "WARN: recess executable not found. Installing it"
+        recessinstall=1
+    else
+        # Have recess, look its version matches expected one
+        recesscurrent=$(${recesscmd} --no-color --version)
+        if [[ "${recesscurrent}" != "${recessversion}" ]]; then
+            echo "WARN: recess executable "${recesscurrent}" found, "${recessversion}" expected. Installing it"
+            recessinstall=1
+        else
+            # All right, recess found and version matches
+            echo "INFO: recess executable (${recessversion}) found"
+        fi
+    fi
+    if [[ -n ${recessinstall} ]]; then
+        ${npmcmd} --no-color install recess@${recessversion}
+        echo "INFO: recess executable (${recessversion}) installed"
+        exitstatus=${PIPESTATUS[0]}
+        if [[ ${exitstatus} -ne 0 ]]; then
+            echo "ERROR: Problems installing recess ${recessversion}"
+            exit $exitstatus
+        fi
+    fi
+fi
+
+
+# Output information about installed binaries.
+echo "INFO: Installation ended"
+echo "INFO: Available binaries @ ${gitdir}"
+echo "INFO: (Contents of $(${npmcmd} bin))"
+for binary in $(ls $(${npmcmd} bin)); do
+    echo "INFO:    - Installed ${binary}"
+done

--- a/prepare_npm_stuff/prepare_npm_stuff.sh
+++ b/prepare_npm_stuff/prepare_npm_stuff.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # $gitdir: Directory containing git repo
 # $gitbranch: Branch we are going to install the DB
-# $extrapath: Extra paths to be available (global)
 # $npmcmd: Path to the npm executable (global)
 # $npmbase: Base directory where we'll store multiple npm packages versions (subdirectories per branch)
 # $shifterversion: Optional, defaults to 0.4.6. Not installed if there is a package.json file (present in 29 and up)
@@ -10,7 +9,7 @@
 # Let's be strict. Any problem leads to failure.
 set -e
 
-required="gitdir gitbranch extrapath npmcmd npmbase"
+required="gitdir gitbranch npmcmd npmbase"
 for var in $required; do
     if [ -z "${!var}" ]; then
         echo "ERROR: ${var} environment variable is not defined. See the script comments."
@@ -20,11 +19,6 @@ done
 
 # calculate some variables
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-# Let add $extrapath to PATH
-if [[ -n ${extrapath} ]]; then
-    export PATH=${PATH}:${extrapath}
-fi
 
 # Apply some defaults.
 shifterversion=${shifterversion:-0.4.6}


### PR DESCRIPTION
Right now there are a bunch of jobs requiring the
installation of different nodejs stuff with npm.

A) Chain of jobs by branch.

- For branches < 29 (without package.json file):
  - The job 'shifter_walk' uses 'shifterbase' to maintain different
    shifter versions per branch. (current value ~/shifter_base)
  - The job 'less_checker' uses 'recessbase' to maintain different
    recess versions per branch. (current value ~/recess_base)
- For branches >= 29 (with package.json file):
  - The job 'grunt_process' uses 'npmbase' to maintain different stuff
    (grunt, shifter, less, jshint...) per branch. (current value
    ~npm_base).

B) Prechecker.

  - The job 'remote_branch_checker'' uses 'npmbase' to maintain different
    stuff (grunt, shifter, less, jshint...) per branch. (current value
    ~npm_base_prechecker). Run by 'grunt_process' above.

C) New uses could also require the installation of npm stuff. For sure
   in a different base from the already used above.

So, this new job is a "universal" nodejs stuff installer, behaving as
follows:

1) npm will be in charge of installing any package.
2) every use above (A, B, C) will use a different 'npmbase'.
3) within every 'npmbase' stuff will be installed per branch, aka:
  - A's own npmbase/branchname/node_modules
  - B's own npmbase/branchname/node_modules
  - ....

4) If package.json is available, both grunt-cli and package.json stuff
   will be installed. This is the way in 29 and up.
5) If package.json is not available, but shifterversion has been
   specified, shifter@version will be installed. This is for < 29.
5) If package.json is not available, but recessversion has been
   specified, recess@version will be installed. This is for < 29.
6) At the end of the process all the installed binaries @
   node_modules/bin will be listed.
7) Link the correct node_modules directory in the gitdir being used. The
   job using the installer will be in charge, if needed, of deleting the
   link once the job is done.

Important note: This job does not perform any git operation (fetch,
checkout...). Just requires the gitdir and gitbranch params in order to
decide where packages will be installed and linked to.

Once this job is available, the idea is to use it for new uses (C above)
and also, progresively, replace all the current A & B uses above.

That's it. Next step, replace, in the A, B jobs above, current partial
installers of nodejs stuff by this universal alternative.