### PR TITLE
MDLSITE-4419: legacy recess 1.1.9 is the only one for old branches

### DIFF
--- a/prepare_npm_stuff/prepare_npm_stuff.sh
+++ b/prepare_npm_stuff/prepare_npm_stuff.sh
@@ -4,7 +4,8 @@
 # $npmcmd: Path to the npm executable (global)
 # $npmbase: Base directory where we'll store multiple npm packages versions (subdirectories per branch)
 # $shifterversion: Optional, defaults to 0.4.6. Not installed if there is a package.json file (present in 29 and up)
-# $recessversion: Optional, defaults to 1.1.6. Not installed if there is a package.json file (present in 29 and up)
+# $recessversion: Optional, defaults to 1.1.9 (Important! it's the only legacy version working. Older ones
+#    lead to empty results). Not installed if there is a package.json file (present in 29 and up)
 
 # Let's be strict. Any problem leads to failure.
 set -e
@@ -22,7 +23,7 @@ mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Apply some defaults.
 shifterversion=${shifterversion:-0.4.6}
-recessversion=${recessversion:-1.1.6}
+recessversion=${recessversion:-1.1.9}
 
 # Move to base directory
 cd ${gitdir}


### PR DESCRIPTION
Using any other (older) version leads to incompatible lessc > 1.4
installed and less files not being processed. So, for the lifes of
27 and 28, we'll be using that 1.1.9 version.

29 and up, not affected, they don't use recess anymore.