### PR TITLE
MDLSITE-2839 relax commit message detector

### DIFF
--- a/tracker_automations/check_marked_as_integrated/util.sh
+++ b/tracker_automations/check_marked_as_integrated/util.sh
@@ -4,7 +4,7 @@ set -e
 
 # Checks if any commit from $2 issue is present in the specified major branch.
 function check_issue () {
-    if [[ -z $( ${1} log  --grep "^${2} " --pretty=oneline --abbrev-commit ${3} ) ]]; then
+    if [[ -z $( ${1} log  --grep "${2}" --pretty=oneline --abbrev-commit ${3} ) ]]; then
         return 1
     fi
     return 0


### PR DESCRIPTION
We have the pre-checker to check for messages in the exact right format,
here we should just search for related commits less striclty