### PR TITLE
MDLSITE-3782 precheck javascript with ESLint when present

### DIFF
--- a/remote_branch_checker/lib.php
+++ b/remote_branch_checker/lib.php
@@ -92,19 +92,38 @@ class remote_branch_reporter {
             }
         }
 
-        // Process the jshint output, weighting errors with 5 and warnings with 1
-        $params = array(
-            'title' => 'Javascript coding style problems',
-            'abbr' => 'js',
-            'description' => 'This section shows the coding style problems detected in the code by jshint',
-            'url' => 'https://docs.moodle.org/dev/Javascript/Coding_style',
-            'codedir' => dirname($this->directory) . '/',
-            'errorweight' => 5,
-            'warningweight' => 1);
-        if ($node = $this->apply_xslt($params, $this->directory . '/jshint.xml', 'checkstyle2smurf.xsl')) {
-            if ($check = $node->getElementsByTagName('check')->item(0)) {
-                $snode = $doc->importNode($check, true);
-                $smurf->appendChild($snode);
+        // For the 'js coding style problems section', conditionally use eslint or jshint
+        if (file_exists($this->directory . '/eslint.xml')) {
+            // Process the jshint output, weighting errors with 5 and warnings with 1
+            $params = array(
+                'title' => 'Javascript coding style problems',
+                'abbr' => 'js',
+                'description' => 'This section shows the coding style problems detected in the code by eslint',
+                'url' => 'https://docs.moodle.org/dev/Javascript/Coding_style',
+                'codedir' => dirname($this->directory) . '/',
+                'errorweight' => 5,
+                'warningweight' => 1);
+            if ($node = $this->apply_xslt($params, $this->directory . '/eslint.xml', 'checkstyle2smurf.xsl')) {
+                if ($check = $node->getElementsByTagName('check')->item(0)) {
+                    $snode = $doc->importNode($check, true);
+                    $smurf->appendChild($snode);
+                }
+            }
+        } else {
+            // Process the jshint output, weighting errors with 5 and warnings with 1
+            $params = array(
+                'title' => 'Javascript coding style problems',
+                'abbr' => 'js',
+                'description' => 'This section shows the coding style problems detected in the code by jshint',
+                'url' => 'https://docs.moodle.org/dev/Javascript/Coding_style',
+                'codedir' => dirname($this->directory) . '/',
+                'errorweight' => 5,
+                'warningweight' => 1);
+            if ($node = $this->apply_xslt($params, $this->directory . '/jshint.xml', 'checkstyle2smurf.xsl')) {
+                if ($check = $node->getElementsByTagName('check')->item(0)) {
+                    $snode = $doc->importNode($check, true);
+                    $smurf->appendChild($snode);
+                }
             }
         }
 


### PR DESCRIPTION
ESLint superseeds jshint, when MDL-52127 lands we'll have much better JS coding style checking. This adds patch support to the prechecker whilst providing BC with old branches with jshint. 

After we've given this a bit of time to settle I actually would propose we jshint from the prechecker completely, and make ESlint work on older branches instead (we'd still get lint jshint reported by grunt  for amd/yui files). See also MDL-54889.