### PR TITLE
NOBUG: Detect grunt failures properly

### DIFF
--- a/grunt_process/grunt_process.sh
+++ b/grunt_process/grunt_process.sh
@@ -52,8 +52,8 @@ gruntcmd="$(${npmcmd} bin)"/grunt
 if [ -x $gruntcmd ]; then
     set +e
     $gruntcmd --no-color > >(tee "${outputfile}") 2> >(tee "${outputfile}".stderr >&2)
-    set -e
     exitstatus=$?
+    set -e
 else
     echo "Error: grunt executable not found" | tee "${outputfile}"
     exit 1


### PR DESCRIPTION
I'm slightly confused because i'm sure i've seen this working, but right
now if the grunt command fails it immediately exits without completing
other parts of the script and doens't add an error in the the
grunt-errors.txt. That meant the prechecker didn't detect any failures..

I don't generally like swiddling set -e and set +e, but this was least destructive way