### PR TITLE
MDLSITE-4419 - Move all jobs to use the new prepare_npm_stuff installer

### DIFF
--- a/prepare_npm_stuff/prepare_npm_stuff.sh
+++ b/prepare_npm_stuff/prepare_npm_stuff.sh
@@ -46,12 +46,13 @@ else
     echo "OK: npmbase for branch (${gitbranch}) found"
 fi
 
-# Linking it (after removing, just in case)
-echo "INFO: Linking ${npmbase}/${gitbranch}/node_modules to ${gitdir}/node_modules"
-ln -nfs ${npmbase}/${gitbranch}/node_modules ${gitdir}/node_modules
-
 # Install general stuff only if there is a package.json file
 if [[ -f ${gitdir}/package.json ]]; then
+
+    # Linking it (after removing, just in case)
+    echo "INFO: Linking ${npmbase}/${gitbranch}/node_modules to ${gitdir}/node_modules"
+    ln -nfs ${npmbase}/${gitbranch}/node_modules ${gitdir}/node_modules
+
     echo "INFO: Installing npm stuff following package/shrinkwrap details"
 
     # Always run npm install to keep our npm packages correct
@@ -64,6 +65,8 @@ if [[ -f ${gitdir}/package.json ]]; then
         ${npmcmd} install --no-color grunt-cli
     fi
 else
+
+    cd ${npmbase}/${gitbranch}
 
     # Install shifter version if there is not package.json
     # (this is required for branches < 29_STABLE)

--- a/prepare_npm_stuff/prepare_npm_stuff.sh
+++ b/prepare_npm_stuff/prepare_npm_stuff.sh
@@ -54,15 +54,15 @@ ln -nfs ${npmbase}/${gitbranch}/node_modules ${gitdir}/node_modules
 if [[ -f ${gitdir}/package.json ]]; then
     echo "INFO: Installing npm stuff following package/shrinkwrap details"
 
+    # Always run npm install to keep our npm packages correct
+    ${npmcmd} --no-color install
+
     # Verify there is a grunt executable available, installing if missing
     gruntcmd="$(${npmcmd} bin)"/grunt
     if [[ ! -f ${gruntcmd} ]]; then
         echo "WARN: grunt-cli executable not found. Installing everything"
         ${npmcmd} install --no-color grunt-cli
     fi
-
-    # Always run npm install to keep our npm packages correct
-    ${npmcmd} --no-color install
 else
 
     # Install shifter version if there is not package.json

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -278,6 +278,11 @@ echo "List of excluded paths"
 echo "${excluded}"
 echo
 
+# Everything is ready, let's install all the required node stuff that some tools will use.
+${mydir}/../prepare_npm_stuff/prepare_npm_stuff.sh
+# And unset npmbase because we don't want those tools to handle node_modules themselves
+npmbase=
+
 # Before deleting all the files not part of the patchest we calculate the
 # complete list of valid components (plugins, subplugins and subsystems)
 # so later various utilities can use it for their own checks/reports.
@@ -336,7 +341,7 @@ cat "${WORKSPACE}/work/phplint.txt" | ${phpcmd} ${mydir}/checkstyle_converter.ph
 ${mydir}/../thirdparty_check/thirdparty_check.sh > "${WORKSPACE}/work/thirdparty.txt"
 cat "${WORKSPACE}/work/thirdparty.txt" | ${phpcmd} ${mydir}/checkstyle_converter.php --format=thirdparty > "${WORKSPACE}/work/thirdparty.xml"
 
-# Run the grunt checker if Gruntfile exists.
+# Run the grunt checker if Gruntfile exists. node stuff has been already installed.
 if [ -f ${WORKSPACE}/Gruntfile.js ]; then
     echo "Running grunt.."
     ${mydir}/../grunt_process/grunt_process.sh > "${WORKSPACE}/work/grunt.txt" 2> "${WORKSPACE}/work/grunt-errors.txt"
@@ -380,6 +385,9 @@ find ${WORKSPACE} -type d -depth -empty -and -not \( -name .git -or -name work \
 set +e
 
 # Now run all the checks that only need the patchset affected files
+
+# Don't need node stuff anymore, avoid it being analysed by any of the next tools.
+rm ${gitdir}/node_modules
 
 # Run the upgrade savepoints checker, converting it to checkstyle format
 # (it requires to be installed in the root of the dir being checked)

--- a/shifter_walk/shifter_walk.sh
+++ b/shifter_walk/shifter_walk.sh
@@ -1,13 +1,24 @@
 #!/bin/bash
+# $WORKSPACE: Directory where results/artifacts will be created
 # $gitdir: Directory containing git repo
 # $gitbranch: Branch we are going to install the DB
 # $extrapath: Extra paths to be available (global)
+# $gitcmd: Path to the git executable (global)
 # $npmcmd: Path to the npm executable (global)
 # $shifterbase: Base directory where we'll store multiple shifter versions (can be different by branch)
-# $shifterversion: Version of shifter to be used by this job
+# $shifterversion: (optional) Version of shifter to be used by this job
 
 # Let's be strict. Any problem leads to failure.
 set +e
+
+# Verify everything is set
+required="WORKSPACE gitdir gitbranch extrapath gitcmd npmcmd shifterbase"
+for var in ${required}; do
+    if [ -z "${!var}" ]; then
+        echo "Error: ${var} environment variable is not defined. See the script comments."
+        exit 1
+    fi
+done
 
 # Let add $path to PATH
 if [[ -n ${extrapath} ]]; then
@@ -25,41 +36,27 @@ cd ${gitdir} && git reset --hard ${gitbranch}
 rm -fr config.php
 rm -fr ${outputfile}
 
-# Verify we have the shifterbase dir, creating if needed
-if [[ ! -d ${shifterbase} ]]; then
-    echo "WARN: shifterbase dir (${shifterbase}) not found. Creating it"
-    mkdir -p ${shifterbase}
-    echo "NOTE: shifterbase dir (${shifterbase}) created"
-else
-    echo "OK: shifterbase dir (${shifterbase}) found"
-fi
-
-# Verify we have already the shifterversion dir, creating if needed
-if [[ ! -d ${shifterbase}/${shifterversion} ]]; then
-    echo "WARN: shifterversion dir (${shifterversion}) not found. Creating it"
-    mkdir -p ${shifterbase}/${shifterversion}
-    echo "NOTE: shifterversion dir (${shifterversion}) created"
-else
-    echo "OK: shifterversion dir (${shifterversion}) found"
-fi
-
-# Verify there is a shifter executable available, installing id neeed
-if [[ ! -f ${shifterbase}/${shifterversion}/node_modules/shifter/bin/shifter ]]; then
-    echo "WARN: shifter executable (${shifterversion}) not found. Installing it"
-    cd ${shifterbase}/${shifterversion}
-    ${npmcmd} install shifter@${shifterversion}
-    echo "NOTE: shifter executable (${shifterversion}) installed"
-else
-    echo "OK: shifter executable (${shifterversion}) found"
-fi
+# Prepare all the npm stuff if needed
+export npmbase=${shifterbase}
+${mydir}/../prepare_npm_stuff/prepare_npm_stuff.sh
 
 # Run shifter against the git repo
 cd ${gitdir}
+
+shiftercmd="$(cd ${shifterbase}/${gitbranch}/node_modules && ${npmcmd} bin)"/shifter
+if [ ! -x $shiftercmd ]; then
+    echo "Error: shifter executable not found" | tee "${outputfile}"
+    exit 1
+fi
+
 # First delete all shifted files so we can detect stale files in the build dir
 rm -fr `find . -path '*/yui/build' -type d`
 
-${shifterbase}/${shifterversion}/node_modules/shifter/bin/shifter --walk --recursive | tee "${outputfile}"
+set +e
+${shiftercmd} --walk --recursive | tee "${outputfile}"
 exitstatus=${PIPESTATUS[0]}
+set -e
+
 if [ $exitstatus -ne 0 ]; then
     echo "ERROR: Problems running shifter" | tee -a "${outputfile}"
     exit $exitstatus


### PR DESCRIPTION
This makes the jobs needing it:

- shifter_walk for < 29_STABE (chained job)
- less_checker for < 29_STABLE (chained job)
- grunt_process for >= 29_STABLE (both chained job and executed by remote_branch_checker)
- remote_branch_checker 

to execute the new prepare_npm_stuff, instead of handling installation their own.

for < 29_STABLE branches, the stuff is installed into the desired base, but the node_modules link is not created and they are executed from base.

for >= 29_STABLE branches, where there is already a Gruntfile, package.json and npm-shrinkwrap.json, the results are linked to node_modules so everything can be executed from there.

I've tested all executions manually and they seem to be working ok. So I've also deployed this PR in the laptop (by pushing in to the laptop branch).

Once verified that everything is working there, this PR (to master) should be considered.

Ciao :-)