### PR TITLE
HQ-1069 git gc: Apply for common collector in security clones

### DIFF
--- a/git_garbage_collector/git_garbage_collector.sh
+++ b/git_garbage_collector/git_garbage_collector.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# $gitcmd: Path to git executable.
+# $gitdir:  Directory containing git repo.
+# $gcinterval: Number of runs before performing a manual gc of the repo. Defaults to 25. 0 means disabled.
+# $gcaggressiveinterval: Number of runs before performing an aggressive gc of the repo. Defaults to 900. 0 means disabled.
+
+# Want exit on error.
+set -e
+
+# Apply some defaults
+gcinterval=${gcinterval:-25}
+gcaggressiveinterval=${gcaggressiveinterval:-900}
+
+# Verify everything is set
+required="gitcmd gitdir"
+for var in ${required}; do
+    if [ -z "${!var}" ]; then
+        echo "Error: ${var} environment variable is not defined. See the script comments."
+        exit 1
+    fi
+done
+
+# Calculate some variables
+mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Verify we are under a git repo.
+if [[ ! -d "${gitdir}/.git" ]]; then
+    echo "Error: Incorrect or non-git gitdir passed. Please fix it."
+    exit 1
+fi
+
+cd "${gitdir}"
+
+# Let's verify if a git gc is required.
+
+random=${RANDOM}
+if [[ -n "${BUILD_TAG}" ]]; then # Running jenkins, use build number.
+    random=${BUILD_NUMBER}
+fi
+
+if [[ ${gcaggressiveinterval} -gt 0 ]] && [[ $((${random} % ${gcaggressiveinterval})) -eq 0 ]]; then
+    echo "Info: Executing git gc --aggressive"
+    ${gitcmd} gc --aggressive --quiet
+elif [[ ${gcinterval} -gt 0 ]] && [[ $((${random} % ${gcinterval})) -eq 0 ]]; then
+    echo "Info: Executing git gc"
+    ${gitcmd} gc --quiet
+fi

--- a/rebase_security/rebase_security.sh
+++ b/rebase_security/rebase_security.sh
@@ -152,6 +152,9 @@ info "Cleaning worktree"
 $gitcmd clean -dfx
 $gitcmd reset --hard
 
+# Let's verify if a git gc is required.
+${mydir}/../git_garbage_collector/git_garbage_collector.sh
+
 # Set our local wd to current state of security repo.
 # (NOTE: checkout -B means create if branch doesn't exist or reset if it does.)
 $gitcmd checkout -B $securitybranch security/$securitybranch

--- a/tracker_automations/check_marked_as_integrated/check_marked_as_integrated.sh
+++ b/tracker_automations/check_marked_as_integrated/check_marked_as_integrated.sh
@@ -59,6 +59,11 @@ errors=()
 
 # Move to the repo.
 cd $gitdir
+
+# Let's verify if a git gc is required.
+${mydir}/../../git_garbage_collector/git_garbage_collector.sh
+
+# Fetch stuff.
 ${gitcmd} fetch ${gitremotename}
 
 # Iterate over found issues and check that their commits are integrated in the


### PR DESCRIPTION
This implements a common git gc cleaner and moves current jobs
needing it (remote_branch_checker and rebase_securty) to use it.

Frequency can be adjusted using gcinterval (defaults to 25) and
gcaggressiveinterval (defaults to 900) if needed.