### PR TITLE
HQ-1070 don't use colors in grunt output

### DIFF
--- a/rebase_security/rebase_security.sh
+++ b/rebase_security/rebase_security.sh
@@ -36,7 +36,7 @@ function compile_less() {
 
     # Grunt is available since Moodle 2.9, fallback to recess.
     if grunt_available; then
-        $gruntcmd "css"
+        $gruntcmd --no-color "css"
     else
         $recesscmd --compile --compress theme/bootstrapbase/less/moodle.less > "$moodlecssfile"
         $recesscmd --compile --compress theme/bootstrapbase/less/editor.less > "$editorcssfile"
@@ -50,7 +50,7 @@ function compile_js() {
 
     # Grunt is available since Moodle 2.9, fallback to shifter (only YUI modules before).
     if grunt_available; then
-        $gruntcmd "js"
+        $gruntcmd --no-color "js"
     else
         $shiftercmd --walk --recursive
     fi


### PR DESCRIPTION
I am sure grunt is supposed to autodetect this, but it doens't seem to be, so avoid those horrible colour escape sequences.

Seen here:
http://integration.moodle.org/job/99.%20SECURITY.%20Rebase%20security%20branch%20(30_STABLE)/549/console
```
[4mRunning "less:bootstrapbase" (less) task[24m
[32m>> [39m2 stylesheets created.
```