### PR TITLE
MDL-52127 eslint: ignorefiles task is not there any more

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -372,7 +372,7 @@ find ${WORKSPACE} -type d -depth -empty -and -not \( -name .git -or -name work \
 if [ -f $WORKSPACE/.eslintrc ]; then
     eslintcmd="$(${npmcmd} bin)"/eslint
     if [ -x $eslintcmd ]; then
-        "$(${npmcmd} bin)"/grunt ignorefiles
+        #"$(${npmcmd} bin)"/grunt ignorefiles
         $eslintcmd -f checkstyle $WORKSPACE > "${WORKSPACE}/work/eslint.xml"
     else
         echo "Error: .eslintrc file found, but eslint executable not found" | tee -a ${errorfile}


### PR DESCRIPTION
ust decided to comment the line instead of deleting in case there
is a chance of getting it back when the subdirectories problem
is fixed and the task is back. See MDL-54930 for more info