### PR TITLE
MDLSITE-4644 prechecker: make eslint to run out from exit-on-error

### DIFF
--- a/prepare_npm_stuff/prepare_npm_stuff.sh
+++ b/prepare_npm_stuff/prepare_npm_stuff.sh
@@ -3,6 +3,7 @@
 # $gitbranch: Branch we are going to install the DB
 # $npmcmd: Path to the npm executable (global)
 # $npmbase: Base directory where we'll store multiple npm packages versions (subdirectories per branch)
+# $nodecmd: Optional, path to the node executable (global)
 # $shifterversion: Optional, defaults to 0.4.6. Not installed if there is a package.json file (present in 29 and up)
 # $recessversion: Optional, defaults to 1.1.9 (Important! it's the only legacy version working. Older ones
 #    lead to empty results). Not installed if there is a package.json file (present in 29 and up)
@@ -24,6 +25,14 @@ mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Apply some defaults.
 shifterversion=${shifterversion:-0.4.6}
 recessversion=${recessversion:-1.1.9}
+
+# Print nodejs and npm versions for informative purposes
+if [[ -x ${nodecmd} ]]; then
+    echo "INFO: node version: $(${nodecmd} --version)"
+fi
+if [[ -x ${npmcmd} ]]; then
+    echo "INFO: npm  version: $(${npmcmd} --version)"
+fi
 
 # Move to base directory
 cd ${gitdir}


### PR DESCRIPTION
It seems that in the last move we did put eslint under an
exit-on-error section within the codechecker. That was leading
to executions exiting with error when eslint detected some
coding-style  problem.

Note the fix is not the perfect fix, just a quick attempt to keep
the things working. There are some linked issues where real
improvements should happen:

- MDLSITE-4625, about to properly inspect exit codes an output
    for every check and be able to discern correct executions
    from incorrect ones.
- MDLSITE-4211, about to have the codechecker, and other local_ci
    stuff covered by own unit tests.