### PR TITLE
MDLSITE-3831 Improve handling of both binary and with-whitespace files

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -324,8 +324,8 @@ if [[ -z "${isplugin}" ]]; then
 fi
 
 # Run the php linter (php_lint)
-${mydir}/../php_lint/php_lint.sh > "${WORKSPACE}/work/phplint.txt"
 echo "Running php lint..."
+${mydir}/../php_lint/php_lint.sh > "${WORKSPACE}/work/phplint.txt"
 cat "${WORKSPACE}/work/phplint.txt" | ${phpcmd} ${mydir}/checkstyle_converter.php --format=phplint > "${WORKSPACE}/work/phplint.xml"
 
 ${mydir}/../thirdparty_check/thirdparty_check.sh > "${WORKSPACE}/work/thirdparty.txt"
@@ -360,12 +360,12 @@ for todelete in ${excluded}; do
     if [[ ${todelete} =~ ".git" || ${todelete} =~ "work" ]]; then
         continue
     fi
-    rm -fr ${WORKSPACE}/${todelete}
+    rm -fr "${WORKSPACE}/${todelete}"
 done
 
 # Remove all the files, but the patchset ones and .git and work
 find ${WORKSPACE} -type f -and -not \( -path "*/.git/*" -or -path "*/work/*" \) | \
-    grep -vf ${WORKSPACE}/work/patchset.files | xargs rm
+    grep -vf ${WORKSPACE}/work/patchset.files | xargs -I{} rm {}
 
 # Remove all the empty dirs remaining, but .git and work
 find ${WORKSPACE} -type d -depth -empty -and -not \( -name .git -or -name work \) -delete


### PR DESCRIPTION
This PR contains 2 commits,

- the first one just ensures that paths and files containing whitespaces are properly handled. Note that core does not have files with whitespaces, but still because of another issue, it was reproducible when checking a plugin.
- the second one changes the diff processor and now it's able to handle both binary files and files with whitespaces. Previously they were not being detected... and the prechecker was deleting all them. That was not problematic because those binary files are not subject to any analysis, but was inaccurate and, potentially, prone to cracks. Now t just works and all files are processed.

For more details and tests, https://tracker.moodle.org/browse/MDLSITE-3831 is the issue :-)