### PR TITLE
MDLSITE-4678 grunt_process: run grunt ignorefiles and detect changes

### DIFF
--- a/grunt_process/grunt_process.sh
+++ b/grunt_process/grunt_process.sh
@@ -50,8 +50,16 @@ rm -fr $(find . -path '*/amd/build' -type d)
 # The echo here works around a problem where shifter is sending colours (MDL-52591).
 gruntcmd="$(${npmcmd} bin)"/grunt
 if [ -x $gruntcmd ]; then
+    # Run the default task (same as specifying no arguments)
+    tasks="default"
+
+    if [ -e .eslintignore ]; then
+        # In 3.2 and later run ignorefiles task
+        tasks="$tasks ignorefiles"
+    fi
+
     set +e
-    $gruntcmd --no-color > >(tee "${outputfile}") 2> >(tee "${outputfile}".stderr >&2)
+    $gruntcmd $tasks --no-color > >(tee "${outputfile}") 2> >(tee "${outputfile}".stderr >&2)
     exitstatus=$?
     set -e
 else


### PR DESCRIPTION
I actually developed this by added a bats fixture for this on the unit testing branch before developing, have a look:

 https://github.com/moodlehq/moodle-local_ci/commit/218e58069983c26d83ce3958ae0cc049927a23cc 

Was a useful exercise writing the tests first, I discovered:

1. You need to do the grunt part before npm symlink is disabled (eliminating my initial attempts to run grunt twice, and eventually realising to just specify both tasks)
2. Need to remember to only run it on 3.2+

But [bats is still crap on travis](https://travis-ci.org/danpoltawski/moodle-local_ci/builds/144131676), so bah for my test driven development experience being ruined!