### PR TITLE
MDLSITE-4702: Convert tests to neutral path to prevent regression

### DIFF
--- a/detect_conflicts/detect_conflicts.sh
+++ b/detect_conflicts/detect_conflicts.sh
@@ -52,8 +52,8 @@ then
     prevcount=`tail -1 "$countfile" | cut -s -f3`
 fi
 
-# Count and send to countfile
-count=`cat "$lastfile" | wc -l`
+# Count and send to countfile. The tr is to remove leading spaces on some platforms..
+count=`cat "$lastfile" | wc -l | tr -d '[[:space:]]'`
 echo "$BUILD_NUMBER	$BUILD_TIMESTAMP	$count" >> "$countfile"
 
 # Get best count ever or create it

--- a/illegal_whitespace/illegal_whitespace.sh
+++ b/illegal_whitespace/illegal_whitespace.sh
@@ -52,8 +52,8 @@ then
     prevcount=`tail -1 "$countfile" | cut -s -f3`
 fi
 
-# Count and send to countfile
-count=`cat "$lastfile" | wc -l`
+# Count and send to countfile. The tr is to remove leading spaces on some platforms..
+count=`cat "$lastfile" | wc -l | tr -d '[[:space:]]'`
 echo "$BUILD_NUMBER	$BUILD_TIMESTAMP	$count" >> "$countfile"
 
 # Get best count ever or create it

--- a/phplib/clilib.php
+++ b/phplib/clilib.php
@@ -65,7 +65,7 @@ function cli_input($prompt, $default='', array $options=null, $casesensitiveopti
             $input = strtolower($input);
         }
         if (!in_array($input, $options)) {
-            cli_writeln(get_string('cliincorrectvalueretry', 'admin'));
+            cli_writeln('Incorrect value, please retry');
             return cli_input($prompt, $default, $options, $casesensitiveoptions);
         }
     }

--- a/remote_branch_checker/remote_branch_reporter.php
+++ b/remote_branch_checker/remote_branch_reporter.php
@@ -54,7 +54,7 @@ list($options, $unrecognized) = cli_get_params(array(
 
 if ($unrecognized) {
     $unrecognized = implode("\n  ", $unrecognized);
-    cli_error(get_string('cliunknowoption', 'admin', $unrecognized));
+    cli_error("Unrecognised options:\n{$unrecognized}\n Please use --help option.");
 }
 
 if ($options['help']) {

--- a/tests/01-php_lint.bats
+++ b/tests/01-php_lint.bats
@@ -6,7 +6,6 @@ setup () {
     create_git_branch MOODLE_31_STABLE v3.1.0
 
     export extrapath=.
-    cd $BATS_TEST_DIRNAME/../php_lint/
 }
 
 @test "php_lint: lib/moodlelib.php lint free" {
@@ -15,7 +14,7 @@ setup () {
     export GIT_PREVIOUS_COMMIT=$FIXTURE_HASH_BEFORE
     export GIT_COMMIT=$FIXTURE_HASH_AFTER
 
-    run ./php_lint.sh
+    ci_run php_lint/php_lint.sh
 
     # Assert result
     assert_success
@@ -30,7 +29,7 @@ setup () {
     export GIT_PREVIOUS_COMMIT=$FIXTURE_HASH_BEFORE
     export GIT_COMMIT=$FIXTURE_HASH_AFTER
 
-    run ./php_lint.sh
+    ci_run php_lint/php_lint.sh
 
     # Assert result
     assert_failure
@@ -45,7 +44,7 @@ setup () {
     export GIT_PREVIOUS_COMMIT=$FIXTURE_HASH_BEFORE
     export GIT_COMMIT=$FIXTURE_HASH_AFTER
 
-    run ./php_lint.sh
+    ci_run php_lint/php_lint.sh
 
     # Assert result
     assert_success

--- a/tests/01-thirdparty_check.bats
+++ b/tests/01-thirdparty_check.bats
@@ -6,7 +6,6 @@ setup () {
     create_git_branch MOODLE_31_STABLE v3.1.0
 
     export extrapath=.
-    cd $BATS_TEST_DIRNAME/../thirdparty_check/
 }
 
 @test "thirdparty_check: thirdpartyfile modified OK" {
@@ -14,7 +13,7 @@ setup () {
     export initialcommit=$FIXTURE_HASH_BEFORE
     export finalcommit=$FIXTURE_HASH_AFTER
 
-    run ./thirdparty_check.sh
+    ci_run thirdparty_check/thirdparty_check.sh
     assert_success
     assert_output --partial "INFO: Checking for third party modifications from $initialcommit to $finalcommit"
     assert_output --partial "INFO: Detected third party modification in lib/amd/src/mustache.js"
@@ -27,7 +26,7 @@ setup () {
     export initialcommit=$FIXTURE_HASH_BEFORE
     export finalcommit=$FIXTURE_HASH_AFTER
 
-    run ./thirdparty_check.sh
+    ci_run thirdparty_check/thirdparty_check.sh
     assert_success # TODO, this should be fixed!
     assert_output --partial "INFO: Checking for third party modifications from $initialcommit to $finalcommit"
     assert_output --partial "INFO: Detected third party modification in lib/amd/src/mustache.js"

--- a/tests/02-checkstyle_manipulations.bats
+++ b/tests/02-checkstyle_manipulations.bats
@@ -2,10 +2,6 @@
 
 load libs/shared_setup
 
-setup () {
-    cd $BATS_TEST_DIRNAME/../
-}
-
 # Helper to assert checkstyle converts
 # usage: assert_checkstyle phpscript fixturefilename expectedfilename
 assert_checkstyle() {
@@ -15,7 +11,7 @@ assert_checkstyle() {
 
     xmlfile=$BATS_TMPDIR/out.xml
 
-    cat $fixture | php $phpscript > $xmlfile
+    ci_run_php "$phpscript < $fixture > $xmlfile"
     assert_success
     diff -ruN $expected $xmlfile
     assert_output ''

--- a/tests/02-diff_extract_changes.bats
+++ b/tests/02-diff_extract_changes.bats
@@ -2,10 +2,6 @@
 
 load libs/shared_setup
 
-setup () {
-    cd $BATS_TEST_DIRNAME/../
-}
-
 # Helper to assert diff_extract_changes output
 # usage: pssert_diff_extract_changes format fixturefilename expectedfilename
 assert_diff_extract_changes() {
@@ -15,7 +11,7 @@ assert_diff_extract_changes() {
 
     out=$BATS_TMPDIR/diff_extract_changes-out
 
-    php diff_extract_changes/diff_extract_changes.php --diff=$fixture --output=$format > $out
+    ci_run_php "diff_extract_changes/diff_extract_changes.php --diff=$fixture --output=$format > $out"
     assert_success
     diff -ruN $expected $out
     assert_output ''

--- a/tests/02-less_checker.bats
+++ b/tests/02-less_checker.bats
@@ -2,7 +2,6 @@
 
 load libs/shared_setup
 
-
 setup () {
     create_git_branch MOODLE_27_STABLE v2.7.14
 
@@ -10,11 +9,10 @@ setup () {
     # Setup recess base.
     export recessbase=$LOCAL_CI_TESTS_CACHEDIR/recess
     mkdir -p $recessbase
-    cd $BATS_TEST_DIRNAME/../less_checker/
 }
 
 @test "less_checker: normal" {
-    run ./less_checker.sh
+    ci_run less_checker/less_checker.sh
     assert_success
     assert_output --partial "OK: All .less files are perfectly compiled and matching git contents"
 }
@@ -22,7 +20,7 @@ setup () {
 @test "less_checker: uncommitted less change" {
     git_apply_fixture 27-less-unbuilt.patch
 
-    run ./less_checker.sh
+    ci_run less_checker/less_checker.sh
     assert_failure
     assert_output --partial "ERROR: Some .less files are not matching git contents. Changes detected:"
     assert_output --partial "theme/bootstrapbase/style/moodle.css"

--- a/tests/02-list_valid_components.bats
+++ b/tests/02-list_valid_components.bats
@@ -4,8 +4,6 @@ load libs/shared_setup
 
 setup () {
     create_git_branch MOODLE_31_STABLE v3.1.0
-
-    cd $BATS_TEST_DIRNAME/../list_valid_components/
 }
 
 @test "list_valid_components: 31 components" {
@@ -16,7 +14,7 @@ setup () {
     OUTPUT=$WORKSPACE/valid_components_out.txt
 
     # Run test
-    php list_valid_components.php --basedir=$gitdir > $OUTPUT
+    ci_run_php "list_valid_components/list_valid_components.php --basedir=$gitdir > $OUTPUT"
     assert_success
     diff -ruN $EXPECTED $OUTPUT
     assert_output ''

--- a/tests/02-remote_branch_reporter.bats
+++ b/tests/02-remote_branch_reporter.bats
@@ -2,10 +2,6 @@
 
 load libs/shared_setup
 
-setup () {
-    cd $BATS_TEST_DIRNAME/../remote_branch_checker/
-}
-
 tearDown() {
     clean_workspace_directory
 }
@@ -30,8 +26,10 @@ assert_remote_branch_reporter() {
 
     testresult=$WORKSPACE/remote_branch_reporter.out
 
-    php remote_branch_reporter.php --directory=$fixture --format=$format --patchset=patchset.xml --repository=$repo --githash=$hash > $testresult
-    diff -ruN $expected $testresult
+    ci_run_php "remote_branch_checker/remote_branch_reporter.php --directory=$fixture --format=$format --patchset=patchset.xml --repository=$repo --githash=$hash > $testresult"
+    assert_success
+    run diff -ruN $expected $testresult
+    assert_success
     assert_output ""
 }
 

--- a/tests/02-travis-branch-checker.bats
+++ b/tests/02-travis-branch-checker.bats
@@ -3,38 +3,34 @@
 load libs/shared_setup
 
 
-setup () {
-    cd $BATS_TEST_DIRNAME/../travis/
-}
-
 @test "travis/check_branch_status.php: missing arguments" {
-    run php check_branch_status.php
+    ci_run_php travis/check_branch_status.php
     assert_failure
 
-    run php check_branch_status.php --repository=https://github.com/moodlehq/moodle-local_ci
+    ci_run_php travis/check_branch_status.php --repository=https://github.com/moodlehq/moodle-local_ci
     assert_failure
 
-    run php check_branch_status.php --branch=master
+    ci_run_php travis/check_branch_status.php --branch=master
     assert_failure
 }
 
-#@test "travis/check_branch_status.php: branch OK" {
-#
-#    run php check_branch_status.php --repository=https://github.com/moodlehq/moodle-local_ci --branch=master
-#    assert_success
-#    assert_output --regexp '^OK: Build status was passed, see '
-#}
+@test "travis/check_branch_status.php: branch OK" {
+    # A branch which Dan has had integrated and won't touch again (and is protected for this purpose)
+    ci_run_php travis/check_branch_status.php --repository=git://github.com/danpoltawski/moodle.git --branch=MDL-52127-master
+    assert_success
+    assert_output 'OK: Build status was passed, see https://travis-ci.org/danpoltawski/moodle/builds/137772508'
+}
 
 @test "travis/check_branch_status.php: no travis setup" {
     # Use a moodlehq github repo which is unlikely to ever have travis integration.
-    run php check_branch_status.php --repository=https://github.com/moodlehq/moodle-theme_afterburner --branch=master
+    ci_run_php travis/check_branch_status.php --repository=https://github.com/moodlehq/moodle-theme_afterburner --branch=master
     assert_success
     assert_output 'WARNING: Travis integration not setup. See https://docs.moodle.org/dev/Travis_Integration'
 }
 
 @test "travis/check_branch_status.php: not github repo" {
     # Travis only works with github repos, so skip non-github ones
-    run php check_branch_status.php --repository=git://git.moodle.org/moodle.git --branch=master
+    ci_run_php travis/check_branch_status.php --repository=git://git.moodle.org/moodle.git --branch=master
     assert_success
     assert_output 'SKIP: Skipping checks. git://git.moodle.org/moodle.git Not a github repo.'
 }

--- a/tests/99-detect_conflicts.bats
+++ b/tests/99-detect_conflicts.bats
@@ -11,7 +11,6 @@ setup () {
     if [ -d $statedir ]; then
         cp -R $statedir/. $WORKSPACE
     fi
-    cd $BATS_TEST_DIRNAME/../detect_conflicts/
 }
 
 teardown () {
@@ -26,7 +25,7 @@ teardown () {
 
     # On first run, there are no results to compare to so should always
     # pass.
-    run ./detect_conflicts.sh
+    ci_run detect_conflicts/detect_conflicts.sh
     assert_success
     assert_output --partial "current count: 0"
     # The 'no previously recorded value' number is 999999
@@ -37,7 +36,7 @@ teardown () {
 
 @test "detect_conflicts: normal state OK" {
     # On second run, should still pass with same results
-    run ./detect_conflicts.sh
+    ci_run detect_conflicts/detect_conflicts.sh
     assert_success
     assert_output --partial "current count: 0"
     assert_output --partial "previous count: 0"
@@ -48,7 +47,7 @@ teardown () {
 @test "detect_conflicts: merge conflict FAIL" {
     git_apply_fixture 31-merge-conflict.patch
 
-    run ./detect_conflicts.sh
+    ci_run detect_conflicts/detect_conflicts.sh
     assert_failure
     assert_output --partial "current count: 3"
     assert_output --partial "previous count: 0"

--- a/tests/99-detect_conflicts.bats
+++ b/tests/99-detect_conflicts.bats
@@ -44,7 +44,7 @@ teardown () {
     assert_output --partial "continue in best results ever"
 }
 
-@test "detect_conflicts: merge conflict FAIL" {
+@test "detect_conflicts: failure reported when merge conflict detected" {
     git_apply_fixture 31-merge-conflict.patch
 
     ci_run detect_conflicts/detect_conflicts.sh

--- a/tests/99-grunt_process.bats
+++ b/tests/99-grunt_process.bats
@@ -2,16 +2,14 @@
 
 load libs/shared_setup
 
-
 setup () {
     create_git_branch MOODLE_31_STABLE v3.1.0
 
     export extrapath=.
-    cd $BATS_TEST_DIRNAME/../grunt_process/
 }
 
 @test "grunt_process: normal" {
-    run ./grunt_process.sh
+    ci_run grunt_process/grunt_process.sh
     assert_success
     assert_output --partial "Done, without errors."
     assert_output --partial "OK: All modules are perfectly processed by grunt"
@@ -22,7 +20,7 @@ setup () {
     git_apply_fixture 31-grunt-less-unbuilt.patch
 
     # Run test
-    run ./grunt_process.sh
+    ci_run grunt_process/grunt_process.sh
 
     # Assert result
     assert_failure
@@ -36,7 +34,7 @@ setup () {
     git_apply_fixture 31-grunt-js-unbuilt.patch
 
     # Run test
-    run ./grunt_process.sh
+    ci_run grunt_process/grunt_process.sh
 
     # Assert result
     assert_failure
@@ -54,11 +52,10 @@ setup () {
     git_apply_fixture 32-thirdparty-lib-added.patch
 
     # Run test
-    run ./grunt_process.sh
+    ci_run grunt_process/grunt_process.sh
 
     # Assert result
     assert_failure
     assert_output --partial "ERROR: Some modules are not properly processed by grunt. Changes detected:"
     assert_output --regexp "GRUNT-CHANGE: (.*)/.eslintignore"
 }
-

--- a/tests/99-illegal_whitespace.bats
+++ b/tests/99-illegal_whitespace.bats
@@ -11,7 +11,6 @@ setup () {
     if [ -d $statedir ]; then
         cp -R $statedir/. $WORKSPACE
     fi
-    cd $BATS_TEST_DIRNAME/../illegal_whitespace/
 }
 
 teardown () {
@@ -26,7 +25,7 @@ teardown () {
 
     # On first run, there are no results to compare to so should always
     # pass.
-    run ./illegal_whitespace.sh
+    ci_run illegal_whitespace/illegal_whitespace.sh
 
     assert_success
     assert_output --partial "current count: 959"
@@ -38,7 +37,7 @@ teardown () {
 
 @test "illegal_whitespace: normal state OK" {
     # On second run, should still pass with same results
-    run ./illegal_whitespace.sh
+    ci_run illegal_whitespace/illegal_whitespace.sh
 
     assert_success
     assert_output --partial "current count: 959"
@@ -51,7 +50,7 @@ teardown () {
     # Lets introduce a whitespace error and ensure it fails
     git_apply_fixture 31-whitespace-error.patch
 
-    run ./illegal_whitespace.sh
+    ci_run illegal_whitespace/illegal_whitespace.sh
     assert_failure
     assert_output --partial "current count: 961"
     assert_output --partial "previous count: 959"

--- a/tests/99-illegal_whitespace.bats
+++ b/tests/99-illegal_whitespace.bats
@@ -46,7 +46,7 @@ teardown () {
     assert_output --partial "continue in best results ever"
 }
 
-@test "illegal_whitespace: whitespace error FAIL" {
+@test "illegal_whitespace: failure reported when whitespace error detected" {
     # Lets introduce a whitespace error and ensure it fails
     git_apply_fixture 31-whitespace-error.patch
 

--- a/tests/99-shifter_walk.bats
+++ b/tests/99-shifter_walk.bats
@@ -9,11 +9,10 @@ setup () {
     # setup shifter base.
     export shifterbase=$LOCAL_CI_TESTS_CACHEDIR/shifter
     mkdir -p $shifterbase
-    cd $BATS_TEST_DIRNAME/../shifter_walk/
 }
 
 @test "shifter_walk: normal" {
-    run ./shifter_walk.sh
+    ci_run shifter_walk/shifter_walk.sh
 
     assert_success
     assert_output --partial "OK: All modules are perfectly shiftered"
@@ -22,7 +21,7 @@ setup () {
 @test "shifter_walk: Uncommitted .js change" {
     git_apply_fixture 27-shifter-unbuildjs.patch
 
-    run ./shifter_walk.sh
+    ci_run shifter_walk/shifter_walk.sh
 
     assert_failure
     assert_output --partial "ERROR: Some modules are not properly shiftered. Changes detected:"

--- a/tests/libs/shared_setup.bash
+++ b/tests/libs/shared_setup.bash
@@ -66,6 +66,18 @@ clean_workspace_directory() {
     cd $OLDPWD # Return to where we were.
 }
 
+# Some custom runners which allow use of relative path
+# NOTE: we use 'bash -c' to allow piping:
+#   -  see https://github.com/sstephenson/bats/issues/10#issuecomment-26627687
+ci_run() {
+    command="$BATS_TEST_DIRNAME/../$@"
+    run bash -c "$command"
+}
+ci_run_php() {
+    command="$BATS_TEST_DIRNAME/../$@"
+    run bash -c "php $command"
+}
+
 # Clean up any $WORKSPACE state (only necessary in case of
 # previously half finished runs)
 clean_workspace_directory

--- a/travis/check_branch_status.php
+++ b/travis/check_branch_status.php
@@ -30,7 +30,7 @@ list($options, $unrecognized) = cli_get_params(
 
 if ($unrecognized) {
     $unrecognized = implode("\n  ", $unrecognized);
-    cli_error(get_string('cliunknowoption', 'admin', $unrecognized));
+    cli_error("Unrecognised options:\n{$unrecognized}\n Please use --help option.");
 }
 
 if ($options['help']) {


### PR DESCRIPTION
Update the tests so that they don't run in the directory of the script to prevent a repeat of [MDLSITE-4702](https://tracker.moodle.org/browse/MDLSITE-4702).

Not ready for merging because i haven't converted  `99-detect_conflicts.bats` or `99-illegal_whitespace.bats` yet - because when I did they break! 

I don't love the variable name test `filedir` - suggestiosn welcome

