### PR TITLE
NOBUG: Make sure clean_worspace_directory removes .files

### DIFF
--- a/tests/00-verifications.bats
+++ b/tests/00-verifications.bats
@@ -63,3 +63,19 @@ load libs/shared_setup
     assert_output ""
 }
 
+@test "clean_workspace_directory() cleans all files" {
+    touch $WORKSPACE/foo
+    touch $WORKSPACE/.bar
+    mkdir $WORKSPACE/subdirectory
+    touch $WORKSPACE/subdirectory/foo
+    touch $WORKSPACE/subdirectory/.bar
+
+    run find $WORKSPACE -type f
+    assert_success
+    refute_output "" # there should be files here..
+
+    clean_workspace_directory
+
+    run find $WORKSPACE -type f
+    assert_output ""
+}

--- a/tests/libs/shared_setup.bash
+++ b/tests/libs/shared_setup.bash
@@ -61,9 +61,8 @@ git_apply_fixture() {
 }
 
 clean_workspace_directory() {
-    # A safe version of rm..
-    cd $WORKSPACE && rm -rf *
-    cd $OLDPWD # Return to where we were.
+    rm -rf $WORKSPACE
+    mkdir $WORKSPACE
 }
 
 # Some custom runners which allow use of relative path


### PR DESCRIPTION
My original implementation of this was to prevent accidents with unset
variables causing an rm -rf /.

But I don't see a neat way to do that..