### PR TITLE
NOBUG: Clean up the code for storing $WORKSPACE between tests

### DIFF
--- a/tests/00-verifications.bats
+++ b/tests/00-verifications.bats
@@ -2,6 +2,16 @@
 
 load libs/shared_setup
 
+@test "first_test(): first reported correctly" {
+    run first_test
+    assert_success
+}
+
+@test "first_test(): !first reported correctly" {
+    run first_test
+    assert_failure
+}
+
 # This test is just used to verify there aren't #!/bin/bash uses in the shell scripts
 # (we should be using env bash for portability)
 @test "#!/bin/bash is not being used in code base" {
@@ -78,4 +88,45 @@ load libs/shared_setup
 
     run find $WORKSPACE -type f
     assert_output ""
+}
+
+@test "workspace cleaned between runs: setup" {
+    touch $WORKSPACE/workspace-dirty-$PPID
+    run [ -f $WORKSPACE/workspace-dirty-$PPID ]
+    assert_success
+}
+
+@test "workspace cleaned between runs: verify" {
+    run [ -f $WORKSPACE/workspace-dirty-$PPID ]
+    assert_failure
+}
+
+@test "store_workspace()" {
+    echo "Created by process: $PPID" > $WORKSPACE/storedfile
+    run [ -f $WORKSPACE/storedfile ]
+    assert_success
+    run store_workspace
+    assert_success
+}
+
+@test "restore_workspace()" {
+    run [ -f $WORKSPACE/storedfile ]
+    assert_failure
+
+    run restore_workspace
+    assert_success
+    run [ -f $WORKSPACE/storedfile ]
+    assert_success
+    run cat $WORKSPACE/storedfile
+    assert_output "Created by process: $PPID"
+}
+
+@test "last_test(): !last reported correctly" {
+    run last_test
+    assert_failure
+}
+
+@test "last_test(): final test reported correctly" {
+    run last_test
+    assert_success
 }

--- a/tests/99-detect_conflicts.bats
+++ b/tests/99-detect_conflicts.bats
@@ -2,27 +2,18 @@
 
 load libs/shared_setup
 
-statedir=$LOCAL_CI_TESTS_CACHEDIR/detect_conflicts/
-
 setup () {
     create_git_branch MOODLE_31_STABLE v3.1.1
-
-    # Reset state between runs.
-    if [ -d $statedir ]; then
-        cp -R $statedir/. $WORKSPACE
-    fi
+    # Restore workspace if not first test.
+    first_test || restore_workspace
 }
 
 teardown () {
-    # Save state between individual runs
-    mkdir -p $statedir
-    cp -R $WORKSPACE/. $statedir
+    # Store workspace if not last test.
+    last_test || store_workspace
 }
 
 @test "detect_conflicts: first run OK" {
-    # Ensure initial state is clean.
-    clean_workspace_directory
-
     # On first run, there are no results to compare to so should always
     # pass.
     ci_run detect_conflicts/detect_conflicts.sh
@@ -53,10 +44,4 @@ teardown () {
     assert_output --partial "previous count: 0"
     assert_output --partial "best count: 0"
     assert_output --partial "worse results than previous counter"
-}
-
-@test "detect_conflicts: clean up state" {
-    # Not a real test, just allows us to avoid storing state after
-    # the rest of the test suite has run.
-    clean_workspace_directory
 }

--- a/tests/99-illegal_whitespace.bats
+++ b/tests/99-illegal_whitespace.bats
@@ -2,27 +2,18 @@
 
 load libs/shared_setup
 
-statedir=$LOCAL_CI_TESTS_CACHEDIR/illegal_whitespace_state/
-
 setup () {
     create_git_branch MOODLE_31_STABLE v3.1.1
-
-    # Reset state between runs.
-    if [ -d $statedir ]; then
-        cp -R $statedir/. $WORKSPACE
-    fi
+    # Restore workspace if not first test.
+    first_test || restore_workspace
 }
 
 teardown () {
-    # Save state between individual runs
-    mkdir -p $statedir
-    cp -R $WORKSPACE/. $statedir
+    # Store workspace if not last test.
+    last_test || store_workspace
 }
 
 @test "illegal_whitespace: first run OK" {
-    # Ensure initial state is clean.
-    clean_workspace_directory
-
     # On first run, there are no results to compare to so should always
     # pass.
     ci_run illegal_whitespace/illegal_whitespace.sh
@@ -56,10 +47,4 @@ teardown () {
     assert_output --partial "previous count: 959"
     assert_output --partial "best count: 959"
     assert_output --partial "worse results than previous counter"
-}
-
-@test "illegal_whitespace: clean up state" {
-    # Not a real test, just allows us to avoid storing state after
-    # the rest of the test suite has run.
-    clean_workspace_directory
 }


### PR DESCRIPTION
* Centralise the code and add tests
* Don't store it in the cache directory - store it in a tmp directory
  which only persists per file/run
* Add helpers for determining when in the first or last test