### PR TITLE
Utilise stylelint in the prechecker (with tests)

### DIFF
--- a/remote_branch_checker/lib.php
+++ b/remote_branch_checker/lib.php
@@ -125,19 +125,37 @@ class remote_branch_reporter {
             }
         }
 
-        // Process the csslint output, weighting errors with 5 and warnings with 1
-        $params = array(
-            'title' => 'CSS problems',
-            'abbr' => 'css',
-            'description' => 'This section shows CSS problems detected by csslint',
-            'url' => 'https://github.com/CSSLint/csslint/wiki/Rules', //TODO: MDLSITE-1796 Create CSS guidelines and link them here.
-            'codedir' => dirname($this->directory) . '/',
-            'errorweight' => 5,
-            'warningweight' => 1);
-        if ($node = $this->apply_xslt($params, $this->directory . '/csslint.xml', 'checkstyle2smurf.xsl')) {
-            if ($check = $node->getElementsByTagName('check')->item(0)) {
-                $snode = $doc->importNode($check, true);
-                $smurf->appendChild($snode);
+        if (file_exists($this->directory . '/stylelint.xml')) {
+            // Process the styleline output, weighting errors with 5 and warnings with 1
+            $params = array(
+                'title' => 'CSS problems',
+                'abbr' => 'css',
+                'description' => 'This section shows CSS problems detected by stylelint',
+                'url' => 'https://docs.moodle.org/dev/CSS_coding_style',
+                'codedir' => dirname($this->directory) . '/',
+                'errorweight' => 5,
+                'warningweight' => 1);
+            if ($node = $this->apply_xslt($params, $this->directory . '/stylelint.xml', 'checkstyle2smurf.xsl')) {
+                if ($check = $node->getElementsByTagName('check')->item(0)) {
+                    $snode = $doc->importNode($check, true);
+                    $smurf->appendChild($snode);
+                }
+            }
+        } else {
+            // Process the csslint output, weighting errors with 5 and warnings with 1
+            $params = array(
+                'title' => 'CSS problems',
+                'abbr' => 'css',
+                'description' => 'This section shows CSS problems detected by csslint',
+                'url' => 'https://github.com/CSSLint/csslint/wiki/Rules', //TODO: MDLSITE-1796 Create CSS guidelines and link them here.
+                'codedir' => dirname($this->directory) . '/',
+                'errorweight' => 5,
+                'warningweight' => 1);
+            if ($node = $this->apply_xslt($params, $this->directory . '/csslint.xml', 'checkstyle2smurf.xsl')) {
+                if ($check = $node->getElementsByTagName('check')->item(0)) {
+                    $snode = $doc->importNode($check, true);
+                    $smurf->appendChild($snode);
+                }
             }
         }
 

--- a/tests/99-remote_branch_checker.bats
+++ b/tests/99-remote_branch_checker.bats
@@ -72,3 +72,8 @@ assert_prechecker () {
     assert_prechecker MDL-53572-master-8ce58c9 MDL-53572 d1a3ea62ef79f2d4d997e329a647535340ef15db \
     "smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0"
 }
+
+@test "remote_branch_checker/remote_branch_checker.sh: stylelint checks" {
+    assert_prechecker prechecker-fixture-stylelint MDL-12345 7752762674c1211e00c5d24045c065c41f5bc662 \
+    "smurf,error,3,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,3,1;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0"
+}

--- a/tests/fixtures/remote_branch_checker/prechecker-fixture-stylelint.xml
+++ b/tests/fixtures/remote_branch_checker/prechecker-fixture-stylelint.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0"?>
+<smurf version="0.9.1" numerrors="3" numwarnings="1">
+  <summary status="error" numerrors="3" numwarnings="1" condensedresult="smurf,error,3,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,3,1;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0">
+    <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="js" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="css" status="error" numerrors="3" numwarnings="1"/>
+    <detail name="phpdoc" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
+  </summary>
+  <check id="phplint" title="PHP lint problems" url="http://php.net/docs.php" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows php lint problems in the code detected by php -l</description>
+    <mess/>
+  </check>
+  <check id="phpcs" title="PHP coding style problems" url="https://docs.moodle.org/dev/Coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the coding style problems detected in the code by phpcs</description>
+    <mess/>
+  </check>
+  <check id="js" title="Javascript coding style problems" url="https://docs.moodle.org/dev/Javascript/Coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the coding style problems detected in the code by eslint</description>
+    <mess/>
+  </check>
+  <check id="css" title="CSS problems" url="https://docs.moodle.org/dev/CSS_coding_style" numerrors="3" numwarnings="1" allowfiltering="1">
+    <description>This section shows CSS problems detected by stylelint</description>
+    <mess>
+      <problem file="report/progress/styles.css" linefrom="4" lineto="4" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/37d67b299413134f176df1c42a8084a726e9a4dd/report/progress/styles.css#L4" ruleset="stylelint" rule="rules.color-hex-case" url="https://docs.moodle.org/dev/CSS_coding_style" type="warning" weight="1">
+        <message>Expected "#EEE" to be "#eee" (color-hex-case)</message>
+        <description/>
+        <code/>
+      </problem>
+      <problem file="report/progress/styles.css" linefrom="4" lineto="4" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/37d67b299413134f176df1c42a8084a726e9a4dd/report/progress/styles.css#L4" ruleset="stylelint" rule="rules.declaration-colon-space-after" url="https://docs.moodle.org/dev/CSS_coding_style" type="error" weight="5">
+        <message>Expected single space after ":" with a single-line declaration (declaration-colon-space-after)</message>
+        <description/>
+        <code/>
+      </problem>
+      <problem file="theme/bootstrapbase/less/moodle/user.less" linefrom="10" lineto="10" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/37d67b299413134f176df1c42a8084a726e9a4dd/theme/bootstrapbase/less/moodle/user.less#L10" ruleset="stylelint" rule="rules.declaration-colon-space-after" url="https://docs.moodle.org/dev/CSS_coding_style" type="error" weight="5">
+        <message>Expected single space after ":" with a single-line declaration (declaration-colon-space-after)</message>
+        <description/>
+        <code/>
+      </problem>
+      <problem file="theme/clean/foo.scss" linefrom="1" lineto="1" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/37d67b299413134f176df1c42a8084a726e9a4dd/theme/clean/foo.scss#L1" ruleset="stylelint" rule="rules.block-no-single-line" url="https://docs.moodle.org/dev/CSS_coding_style" type="error" weight="5">
+        <message>Unexpected single-line block (block-no-single-line)</message>
+        <description/>
+        <code/>
+      </problem>
+    </mess>
+  </check>
+  <check id="phpdoc" title="PHPDocs style problems" url="https://docs.moodle.org/dev/Coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the phpdocs problems detected in the code by local_moodlecheck</description>
+    <mess/>
+  </check>
+  <check id="commit" title="Commit messages problems" url="https://docs.moodle.org/dev/Commit_cheat_sheet#Provide_clear_commit_messages" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the problems detected in the commit messages by the commits checker</description>
+    <mess/>
+  </check>
+  <check id="savepoint" title="Update savepoints problems" url="https://docs.moodle.org/dev/Upgrade_API" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows problems detected with the handling of upgrade savepoints</description>
+    <mess/>
+  </check>
+  <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows files built by grunt and not commited</description>
+    <mess/>
+  </check>
+  <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows problems detected by shifter</description>
+    <mess/>
+  </check>
+  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section reports issues detected by Travis CI.</description>
+    <mess/>
+  </check>
+</smurf>


### PR DESCRIPTION
Based on top of #120 

Taken the same approach as jshint/eslint (although I think particularly with csslint we should get rid of it soon, its doing so little).

Haven't added tests for the reporting for remote_branch_reporter.php yet