### PR TITLE
Ensure stylelint returns a prechecker result, even if not files to check

### DIFF
--- a/tests/99-remote_branch_checker.bats
+++ b/tests/99-remote_branch_checker.bats
@@ -77,3 +77,10 @@ assert_prechecker () {
     assert_prechecker prechecker-fixture-stylelint MDL-12345 7752762674c1211e00c5d24045c065c41f5bc662 \
     "smurf,error,3,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,3,1;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0"
 }
+
+@test "remote_branch_checker/remote_branch_checker.sh: stylelint without cssfiles" {
+    # Ensure we always report css results, even if not css file - from
+    # https://integration.moodle.org/view/prechecker/job/Precheck%20remote%20branch/26281/console
+    assert_prechecker MDL-55445-master-66e47dd MDL-55445 7752762674c1211e00c5d24045c065c41f5bc662 \
+    "smurf,error,3,0:phplint,success,0,0;phpcs,error,3,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0"
+}

--- a/tests/fixtures/remote_branch_checker/MDL-55445-master-66e47dd.xml
+++ b/tests/fixtures/remote_branch_checker/MDL-55445-master-66e47dd.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<smurf version="0.9.1" numerrors="3" numwarnings="0">
+  <summary status="error" numerrors="3" numwarnings="0" condensedresult="smurf,error,3,0:phplint,success,0,0;phpcs,error,3,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0">
+    <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="phpcs" status="error" numerrors="3" numwarnings="0"/>
+    <detail name="js" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="css" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="phpdoc" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
+  </summary>
+  <check id="phplint" title="PHP lint problems" url="http://php.net/docs.php" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows php lint problems in the code detected by php -l</description>
+    <mess/>
+  </check>
+  <check id="phpcs" title="PHP coding style problems" url="https://docs.moodle.org/dev/Coding_style" numerrors="3" numwarnings="0" allowfiltering="1">
+    <description>This section shows the coding style problems detected in the code by phpcs</description>
+    <mess>
+      <problem file="admin/settings/appearance.php" linefrom="55" lineto="55" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/66e47dd7f23a09f140e84c0fa561eb42c5498b40/admin/settings/appearance.php#L55" ruleset="moodle" rule="WhiteSpace.SpaceAfterComma.NoSpace" url="https://docs.moodle.org/dev/Coding_style" type="error" weight="5">
+        <message>Commas (,) must be followed by white space.</message>
+        <description/>
+        <code/>
+      </problem>
+      <problem file="admin/settings/appearance.php" linefrom="58" lineto="58" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/66e47dd7f23a09f140e84c0fa561eb42c5498b40/admin/settings/appearance.php#L58" ruleset="moodle" rule="WhiteSpace.SpaceAfterComma.NoSpace" url="https://docs.moodle.org/dev/Coding_style" type="error" weight="5">
+        <message>Commas (,) must be followed by white space.</message>
+        <description/>
+        <code/>
+      </problem>
+      <problem file="lib/outputrenderers.php" linefrom="305" lineto="305" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/66e47dd7f23a09f140e84c0fa561eb42c5498b40/lib/outputrenderers.php#L305" ruleset="moodle" rule="WhiteSpace.SpaceAfterComma.NoSpace" url="https://docs.moodle.org/dev/Coding_style" type="error" weight="5">
+        <message>Commas (,) must be followed by white space.</message>
+        <description/>
+        <code/>
+      </problem>
+    </mess>
+  </check>
+  <check id="js" title="Javascript coding style problems" url="https://docs.moodle.org/dev/Javascript/Coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the coding style problems detected in the code by eslint</description>
+    <mess/>
+  </check>
+  <check id="css" title="CSS problems" url="https://docs.moodle.org/dev/CSS_coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows CSS problems detected by stylelint</description>
+    <mess/>
+  </check>
+  <check id="phpdoc" title="PHPDocs style problems" url="https://docs.moodle.org/dev/Coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the phpdocs problems detected in the code by local_moodlecheck</description>
+    <mess/>
+  </check>
+  <check id="commit" title="Commit messages problems" url="https://docs.moodle.org/dev/Commit_cheat_sheet#Provide_clear_commit_messages" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the problems detected in the commit messages by the commits checker</description>
+    <mess/>
+  </check>
+  <check id="savepoint" title="Update savepoints problems" url="https://docs.moodle.org/dev/Upgrade_API" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows problems detected with the handling of upgrade savepoints</description>
+    <mess/>
+  </check>
+  <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows files built by grunt and not commited</description>
+    <mess/>
+  </check>
+  <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows problems detected by shifter</description>
+    <mess/>
+  </check>
+  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section reports issues detected by Travis CI.</description>
+    <mess/>
+  </check>
+</smurf>


### PR DESCRIPTION
Fixes a bug which Fred reported - where the css part of report isn't returned when stylelint runs.

I've added a fixture for the branch which I saw this behaviour on