### PR TITLE
MDLSITE-4722 take2 - Make old branches to work

### DIFF
--- a/compare_databases/compare_databases.php
+++ b/compare_databases/compare_databases.php
@@ -164,9 +164,15 @@ function compare_column_specs($tname, $cname, $specs1, $specs2) {
     if (!isset($validelements)) {
         // Use reflection to find all the magic properties of the object.
         $reflection = new ReflectionClass($specs1);
-        $property = $reflection->getProperty('data');
-        $property->setAccessible(true);
-        $validelements = array_keys($property->getValue($specs1));
+        if ($reflection->hasProperty('data')) {
+            // Moodle 3.1 and up, everything is handled magically within the data property).
+            $property = $reflection->getProperty('data');
+            $property->setAccessible(true);
+            $validelements = array_keys($property->getValue($specs1));
+        } else {
+            // Older versions, let's get individual public properties.
+            $validelements = array_keys(get_object_vars($specs1));
+        }
     }
 
     $errors = array();

--- a/tests/99-compare_databases.bats
+++ b/tests/99-compare_databases.bats
@@ -37,7 +37,7 @@ setup () {
     assert_output --partial 'Error: dbtype environment variable is not defined. See the script comments.'
 }
 
-@test "compare_databases/compare_databases.sh: single branch runs work" {
+@test "compare_databases/compare_databases.sh: single actual (>= 31_STABLE) branch runs work" {
     export gitbranchinstalled=master
     export gitbranchupgraded=MOODLE_31_STABLE
 
@@ -54,6 +54,26 @@ setup () {
     assert_output --partial 'Ok: Process ended without errors'
     refute_output --partial 'Error: Process ended with'
     run [ -f $WORKSPACE/compare_databases_master_logfile.txt ]
+    assert_success
+}
+
+@test "compare_databases/compare_databases.sh: single old (< 31_STABLE) branch runs work" {
+    export gitbranchinstalled=v3.0.5
+    export gitbranchupgraded=v3.0.1
+
+    ci_run compare_databases/compare_databases.sh
+    assert_success
+    assert_output --partial 'Info: Origin branches: (1) v3.0.1'
+    assert_output --partial 'Info: Target branch: v3.0.5'
+    assert_output --partial 'Info: Installing Moodle v3.0.5 into ci_installed_'
+    assert_output --partial 'Info: Comparing v3.0.5 and upgraded v3.0.1'
+    assert_output --partial 'Info: Installing Moodle v3.0.1 into ci_upgraded_'
+    assert_output --partial 'Info: Upgrading Moodle v3.0.1 to v3.0.5 into ci_upgraded_'
+    assert_output --partial 'Info: Comparing databases ci_installed_'
+    assert_output --partial 'Info: OK. No problems comparing databases ci_installed_'
+    assert_output --partial 'Ok: Process ended without errors'
+    refute_output --partial 'Error: Process ended with'
+    run [ -f $WORKSPACE/compare_databases_v3.0.5_logfile.txt ]
     assert_success
 }
 


### PR DESCRIPTION
As [commented @ MDLSITE-4722](https://tracker.moodle.org/browse/MDLSITE-4722?focusedCommentId=424622&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-424622), I was performing the final tests when I detected that branches < 31_STABLE were failing. The reason is that the ````database_column-info```` internals are different in those old branches.

So this commit just changes the introspection to work differently for 31_STABLE and up ($data protected property) and older branches (individual public properties).

I've already merged this into laptop, after passing local tests, just to be sure it solves the problem. And it seems to be working ok:

- Before (failing): [link](http://ci7.stronk7.com/view/M27/job/25.%20Compare%20databases%20from%2022-23-24-25-26%20(27_STABLE)/1177/console)
- After (passing): [link](http://ci7.stronk7.com/view/M27/job/25.%20Compare%20databases%20from%2022-23-24-25-26%20(27_STABLE)/1178/console)

This includes the fix and a new bats tests to cover the use of old branches.

Ciao :-)