### PR TITLE
MDLSITE-3688 - detect lack of MOODLE_INTERNAL

### DIFF
--- a/php_lint/php_lint.sh
+++ b/php_lint/php_lint.sh
@@ -70,6 +70,20 @@ for mfile in ${mfiles} ; do
                 echo "$fullpath - ERROR: BOM character found"
                 errorfound=1
             fi
+
+            # (Hacky) MOODLE_INTERNAL check.
+            if [[ ${fulllint} -ne 1 ]]; then
+                # At the moment, we only do this in partial checks. Thats because
+                # we dont have a properly MOODLE_INTERNAL codebase.
+                if ! grep -q -E '(require.*config.php|MOODLE_INTERNAL)' $fullpath
+                then
+                    # The 'on line 1' part is imporant and means problems should only
+                    # be reported by the prechecker when the first line is modified (i.e.
+                    # new file is created).
+                    echo "$fullpath - ERROR: file missing MOODLE_INTERNAL or require config.php on line 1"
+                    errorfound=1
+                fi
+            fi
         else
             # This is a bit of a hack, we should really be using git to
             # get actual file contents from the latest commit to avoid

--- a/tests/01-php_lint.bats
+++ b/tests/01-php_lint.bats
@@ -51,3 +51,31 @@ setup () {
     assert_output --regexp "^Using PHP [0-9]+\.[0-9]+\.[0-9]+"
     assert_output --partial "Running php syntax check from $GIT_PREVIOUS_COMMIT to $GIT_COMMIT"
 }
+
+@test "php_lint: no MOODLE_INTERNAL is detected" {
+    # Set up.
+    git_apply_fixture 31-php_lint-no-moodle-internal.patch
+    export GIT_PREVIOUS_COMMIT=$FIXTURE_HASH_BEFORE
+    export GIT_COMMIT=$FIXTURE_HASH_AFTER
+
+    ci_run php_lint/php_lint.sh
+
+    # Assert result
+    assert_failure
+    assert_output --partial "lib/classes/chart_pie2.php - ERROR: file missing MOODLE_INTERNAL or require config.php on line 1"
+    assert_output --regexp "PHP syntax errors found."
+}
+
+@test "php_lint: entryfile without MOODLE_INTERNAL is OK" {
+    # Set up.
+    git_apply_fixture 31-php_lint-entryfile-ok.patch
+    export GIT_PREVIOUS_COMMIT=$FIXTURE_HASH_BEFORE
+    export GIT_COMMIT=$FIXTURE_HASH_AFTER
+
+    ci_run php_lint/php_lint.sh
+
+    # Assert result
+    assert_success
+    assert_output --partial "entryfile.php - OK"
+    assert_output --partial "No PHP syntax errors found"
+}

--- a/tests/fixtures/31-php_lint-entryfile-ok.patch
+++ b/tests/fixtures/31-php_lint-entryfile-ok.patch
@@ -1,0 +1,38 @@
+From f90cacf71bc5dbf6f5b2bd235de9f99993436500 Mon Sep 17 00:00:00 2001
+From: Dan Poltawski <dan@moodle.com>
+Date: Wed, 31 Aug 2016 17:24:44 +0100
+Subject: [PATCH 1/1] Entryfile
+
+---
+ entryfile.php | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+ create mode 100644 entryfile.php
+
+diff --git a/entryfile.php b/entryfile.php
+new file mode 100644
+index 0000000000..8735a570e9
+--- /dev/null
++++ b/entryfile.php
+@@ -0,0 +1,19 @@
++<?php
++// This file is part of Moodle - http://moodle.org/
++//
++// Moodle is free software: you can redistribute it and/or modify
++// it under the terms of the GNU General Public License as published by
++// the Free Software Foundation, either version 3 of the License, or
++// (at your option) any later version.
++//
++// Moodle is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++//
++// You should have received a copy of the GNU General Public License
++// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
++
++require_once(__DIR__ . '/config.php');
++
++echo 'This file is ok';
+-- 
+2.9.0
+

--- a/tests/fixtures/31-php_lint-no-moodle-internal.patch
+++ b/tests/fixtures/31-php_lint-no-moodle-internal.patch
@@ -1,0 +1,54 @@
+From f39ae0c910aad85d8b407e37fddb1b4d599269f2 Mon Sep 17 00:00:00 2001
+From: Dan Poltawski <dan@moodle.com>
+Date: Wed, 31 Aug 2016 17:19:38 +0100
+Subject: [PATCH 1/1] MDL-12345: add class without MOODLE_INTERNAL
+
+---
+ lib/classes/chart_pie2.php | 35 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+ create mode 100644 lib/classes/chart_pie2.php
+
+diff --git a/lib/classes/chart_pie2.php b/lib/classes/chart_pie2.php
+new file mode 100644
+index 0000000000..a3432e4b33
+--- /dev/null
++++ b/lib/classes/chart_pie2.php
+@@ -0,0 +1,35 @@
++<?php
++// This file is part of Moodle - http://moodle.org/
++//
++// Moodle is free software: you can redistribute it and/or modify
++// it under the terms of the GNU General Public License as published by
++// the Free Software Foundation, either version 3 of the License, or
++// (at your option) any later version.
++//
++// Moodle is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++//
++// You should have received a copy of the GNU General Public License
++// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
++
++/**
++ * Chart pie.
++ *
++ * @package    core
++ * @copyright  2016 Frédéric Massart - FMCorz.net
++ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
++ */
++
++namespace core;
++
++/**
++ * Chart pie class.
++ *
++ * @package    core
++ * @copyright  2016 Frédéric Massart - FMCorz.net
++ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
++ */
++class chart_pie extends chart_base {
++}
+-- 
+2.9.0
+


### PR DESCRIPTION
Created the pull request to discuss the idea/approach. I thought this was going to be a nice way to do it, taking a slightly hacky approach to 'abusing' the php -l check, because it would be filtered by the diff excluder by using 'on line 1' and look at the code, we don't have to add much to achieve it.

But now i'm not so sure, because it'd break the post-checks if any file was modified without a MOODLE_INTERNAL.. I suppose we could potentially add a flag for whether it runs the MOODLE_INTERNAL check, but maybe this is just too much of an abuse.