### PR TITLE
MDLSITE-4767 Ignore CSV files in tests

### DIFF
--- a/define_excluded/define_excluded.sh
+++ b/define_excluded/define_excluded.sh
@@ -80,6 +80,7 @@ webservice/amf/testclient/AMFTester.mxml
 webservice/amf/testclient/customValidators/JSONValidator.as
 work/
 yui/build/
+*.csv
 *.gif
 *.jpg
 *.png


### PR DESCRIPTION
CSV files should not be tested for things like illegal whitespace.