### PR TITLE
MDLSITE-4767 regression: avoid prechecker deleting node_modules

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -355,7 +355,7 @@ echo "Info: Deleting excluded and unrelated files..."
 # Remove all the excluded (but .git and work)
 set -e
 for todelete in ${excluded}; do
-    if [[ ${todelete} =~ ".git" || ${todelete} =~ "work" ]]; then
+    if [[ ${todelete} =~ ".git" || ${todelete} =~ "work" || ${todelete} =~ "node_modules" ]]; then
         continue
     fi
     rm -fr "${WORKSPACE}/${todelete}"


### PR DESCRIPTION
Prechecker, once has finished the tests requiring complete
codebase, proceeds to delete all the non-patch files. That
includes deleting ignored/excluded files.

Since some hours ago we added node_modules to the list of excluded
and that's leading to its deletion, so obviously nothing from
node_modules is available anymore.

So I just have added an exception to guarantee node_modules persists.