### PR TITLE
NOBUG: Avoid the job to modify/fetch new stuff

### DIFF
--- a/compare_databases/compare_databases.sh
+++ b/compare_databases/compare_databases.sh
@@ -64,9 +64,6 @@ if [ $exitstatus -ne 0 ]; then
     exit $exitstatus
 fi
 
-# Ensure we have all branches and tags at hand or some origin objects may not be available
-cd $gitdir && $gitcmd fetch --all && $gitcmd fetch --tags
-
 # Do the moodle install of $installdb
 echo "Info: Installing Moodle $gitbranchinstalled into $installdb" | tee -a "${logfile}"
 # Calculate the proper hash so we branch on it, no matter it's branch, tag or hash


### PR DESCRIPTION
Basically current git status roots the execution.

Looking to those fetches added (recently!) to the database compare
job... i think maybe I added them because of ci tests not ensuring
everything is available in the moodle.git clone (LOCAL_CI_TESTS_GITDIR).
I think I needed it because I was pointing to ongoing integration.git
clone (some tests were dependent of stuff being integrated that week).

I thinkI'm going to, simply, kill the fetches because it's not the job
responsibility to ensure that. travis already does full clone and the
git jobs in jenkins do fetch everything (or can be configured for that f
missing).