### PR TITLE
Properly detect 'full html body' templates

### DIFF
--- a/mustache_lint/mustache_lint.php
+++ b/mustache_lint/mustache_lint.php
@@ -165,10 +165,12 @@ function print_message($severity, $mesage) {
  * Wrap the template content in a html5 wrapper and validate it
  */
 function check_html_validation($content) {
-    if (strpos('<head>', $content) === false) {
+    if (strpos($content, '<head>') === false) {
         // Primative detection if we have full html body, if not, wrap it.
         // (This isn't bulletproof, obviously).
         $wrappedcontent = "<!DOCTYPE html><head><title>Validate</title></head><body>\n{$content}\n</body></html>";
+    } else {
+        $wrappedcontent = $content;
     }
     $response = validate_html($wrappedcontent);
 

--- a/tests/02-mustache_lint.bats
+++ b/tests/02-mustache_lint.bats
@@ -98,3 +98,20 @@ setup () {
     assert_output --partial "blocks/lp/templates/test_partial_loading.mustache - OK: Mustache rendered html succesfully"
     assert_output --partial "No mustache problems found"
 }
+
+@test "mustache_lint: Full HTML page doesn't get embeded in <html> body" {
+    # Set up.
+    git_apply_fixture 31-mustache_lint-full-html-body.patch
+    export GIT_PREVIOUS_COMMIT=$FIXTURE_HASH_BEFORE
+    export GIT_COMMIT=$FIXTURE_HASH_AFTER
+
+    ci_run mustache_lint/mustache_lint.sh
+
+    # Assert result
+    assert_success
+    # We should not have a vlidation warning about multiple 'html' tags.
+    refute_output --partial 'Stray start tag “html”.'
+
+    assert_output --partial "lib/templates/full-html-page.mustache - OK: Mustache rendered html succesfully"
+    assert_output --partial "No mustache problems found"
+}

--- a/tests/fixtures/31-mustache_lint-full-html-body.patch
+++ b/tests/fixtures/31-mustache_lint-full-html-body.patch
@@ -1,0 +1,38 @@
+From d7f48a533d3d1bf7bff0e48d5ad6930b4d0838e7 Mon Sep 17 00:00:00 2001
+From: Dan Poltawski <dan@moodle.com>
+Date: Wed, 2 Nov 2016 10:41:20 +0000
+Subject: [PATCH 1/1] MDL-12345 mustache: fixture for full html
+
+---
+ lib/templates/full-html-page.mustache | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+ create mode 100644 lib/templates/full-html-page.mustache
+
+diff --git a/lib/templates/full-html-page.mustache b/lib/templates/full-html-page.mustache
+new file mode 100644
+index 0000000..386ffb0
+--- /dev/null
++++ b/lib/templates/full-html-page.mustache
+@@ -0,0 +1,19 @@
++{{!
++    @template core/full-html-page
++
++    Full HTML page test.
++
++    Example context (json):
++    {
++       "message": "Hello world!"
++    }
++}}
++<!DOCTYPE html>
++<html>
++<head>
++<title>Test page</title>
++</head>
++<body>
++<p>{{message}}</p>
++</body>
++</html>
+-- 
+2.10.0
+


### PR DESCRIPTION
* There was a logic bug (the arguments to strpos the wrong way round!)
* We didn't se tthe content when full body pages were found oops!