### PR TITLE
MDLSITE-4787 mustache_lint: Handle theme templates better

### DIFF
--- a/mustache_lint/simple_core_component_mustache_loader.php
+++ b/mustache_lint/simple_core_component_mustache_loader.php
@@ -2,10 +2,12 @@
 
 class simple_core_component_mustache_loader extends Mustache_Loader_FilesystemLoader {
 
+    protected $theme = null;
     /**
-     * Provide a default no-args constructor (we don't really need anything).
+     * Constructor.
      */
-    public function __construct() {
+    public function __construct($theme = null) {
+        $this->theme = $theme;
     }
 
     /**
@@ -22,6 +24,17 @@ class simple_core_component_mustache_loader extends Mustache_Loader_FilesystemLo
         }
 
         list($component, $templatename) = explode('/', $name, 2);
+
+        if ($this->theme) {
+            // The real mustache loader handles theme parents - we don't here for simplicity.
+            $themedir = core_component::get_plugin_directory('theme', $this->theme);
+
+            $themetemplate = $themedir . '/templates/' . $component . '/'. $templatename . '.mustache';
+            if (file_exists($themetemplate)) {
+                return $themetemplate;
+            }
+        }
+
         $compdirectory = core_component::get_component_directory($component);
         $path = $compdirectory . '/templates/' . $templatename . '.mustache';
         if (!file_exists($path)) {

--- a/tests/02-mustache_lint.bats
+++ b/tests/02-mustache_lint.bats
@@ -115,3 +115,18 @@ setup () {
     assert_output --partial "lib/templates/full-html-page.mustache - OK: Mustache rendered html succesfully"
     assert_output --partial "No mustache problems found"
 }
+
+@test "mustache_lint: Theme templates load theme partials" {
+    # Set up.
+    git_apply_fixture 31-mustache_lint-theme_loading.patch
+    export GIT_PREVIOUS_COMMIT=$FIXTURE_HASH_BEFORE
+    export GIT_COMMIT=$FIXTURE_HASH_AFTER
+
+    ci_run mustache_lint/mustache_lint.sh
+
+    # Assert that test-theme-loading.mustache validates succesfully.
+    assert_output --partial "theme/bootstrapbase/templates/test-theme-loading.mustache - OK: Mustache rendered html succesfully"
+
+    # But note that this run will fail because of an invalid partial (div-start.mustache) - MDL-56504
+    assert_failure
+}

--- a/tests/fixtures/31-mustache_lint-theme_loading.patch
+++ b/tests/fixtures/31-mustache_lint-theme_loading.patch
@@ -1,0 +1,41 @@
+From 05e34a539f00c89f9dc94bb695af4839b73b1f35 Mon Sep 17 00:00:00 2001
+From: Dan Poltawski <dan@moodle.com>
+Date: Wed, 2 Nov 2016 12:17:41 +0000
+Subject: [PATCH 1/1] MDL-12345 mustache: fixture for theme loading
+
+---
+ .../bootstrapbase/templates/core_output/div-start.mustache  |  1 +
+ theme/bootstrapbase/templates/test-theme-loading.mustache   | 13 +++++++++++++
+ 2 files changed, 14 insertions(+)
+ create mode 100644 theme/bootstrapbase/templates/core_output/div-start.mustache
+ create mode 100644 theme/bootstrapbase/templates/test-theme-loading.mustache
+
+diff --git a/theme/bootstrapbase/templates/core_output/div-start.mustache b/theme/bootstrapbase/templates/core_output/div-start.mustache
+new file mode 100644
+index 0000000..e54a273
+--- /dev/null
++++ b/theme/bootstrapbase/templates/core_output/div-start.mustache
+@@ -0,0 +1 @@
++<div>
+diff --git a/theme/bootstrapbase/templates/test-theme-loading.mustache b/theme/bootstrapbase/templates/test-theme-loading.mustache
+new file mode 100644
+index 0000000..57fd9f0
+--- /dev/null
++++ b/theme/bootstrapbase/templates/test-theme-loading.mustache
+@@ -0,0 +1,13 @@
++{{!
++    @template theme_bootstrapbase/test.mustache
++
++    A bit of a silly template to test that theme partials are being loaded.
++
++    The partial 'core_output/div-start' doesn't exist in at 3.1.2, so this template
++    will only validate when we load from theme_bootstrapbase.
++
++    Example context (json): {}
++}}
++{{> core_output/div-start}}
++Hello World!
++</div>
+-- 
+2.10.0
+


### PR DESCRIPTION
We have theme templates, which load partials which override the core partials and thus, we are validating incorrect results. At first I thought we didn't need to care about themes and that it was too complex, but we can work out which theme is wanted from the path of the template.