### PR TITLE
MDLSITE-4798 misreporting about exit status when checks fail

### DIFF
--- a/define_excluded/define_excluded.sh
+++ b/define_excluded/define_excluded.sh
@@ -105,8 +105,9 @@ if [[ -n ${gitdir} ]]; then
     done
 fi
 
+export LC_ALL=C
 # Sort and get rid of dupes, they (maybe) are legion.
-excluded=$(LC_ALL=C; echo "${excluded}" | sort -u)
+excluded=$(echo "${excluded}" | sort -u)
 
 # Some well-known exceptions... to be deleted once the branch
 # gets out from support

--- a/tracker_automations/bulk_precheck_issues/bulk_precheck_issues.sh
+++ b/tracker_automations/bulk_precheck_issues/bulk_precheck_issues.sh
@@ -243,7 +243,7 @@ while read issue; do
                 # controlled errors/warnings, print them. (exclude info lines, see MDLSITE-4415)
                 perrors=$(echo "${errors}" | grep -v '^Info:' | sed 's/^/    -- /g')
                 echo "${perrors}" | tee -a "${resultfile}.${issue}.txt"
-            elif [[ ${branchresult} == "error" ]]; then
+            elif [[ ${status} -ne 0 ]]; then
                 # Failed prechecker and nothing reported via errors, generic error message
                 echo "  -- CI Job exited with status ${status}. This usually means that you have found some bug in the automated prechecker. Please [report it in the Tracker|https://tracker.moodle.org/secure/CreateIssueDetails!init.jspa?pid=10020&issuetype=1&components=12431&summary=Problem%20with%20job%20XXX] or contact an integrator directly." | tee -a "${resultfile}.${issue}.txt"
             fi


### PR DESCRIPTION
Regression from  b304bc063d3, I used the wrong status. As seen on <a href="https://tracker.moodle.org/browse/MDL-56910?focusedCommentId=438508&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-438508">MDL-56910</a>