### PR TITLE
MDLSITE-4625 Report grunt errors in the prechecker

### DIFF
--- a/remote_branch_checker/checkstyle_converter.php
+++ b/remote_branch_checker/checkstyle_converter.php
@@ -110,6 +110,13 @@ function process_gruntdiff($line) {
         $output.= '<error line="0" column="0" severity="error" ';
         $output.= 'message="Uncommitted change detected."/>' . PHP_EOL;
         $output.= '</file>';
+    } else if (preg_match('/^ERROR: (.*)$/', $line, $matches)) {
+        $error = $matches[1];
+
+        $output.= '<file name="">' . PHP_EOL;
+        $output.= '<error line="0" column="0" severity="error" ';
+        $output.= 'message="'. s($error) .'"/>' . PHP_EOL;
+        $output.= '</file>';
     }
 
     return $output;

--- a/remote_branch_checker/checkstyle_converter.php
+++ b/remote_branch_checker/checkstyle_converter.php
@@ -103,6 +103,7 @@ exit;
  */
 function process_gruntdiff($line) {
     $output = '';
+    // GRUNT-CHANGE: and ERROR: come from grunt_process.sh
     if (preg_match('/^GRUNT-CHANGE: (\S+)$/', $line, $matches)) {
         $filename = $matches[1];
 
@@ -117,8 +118,15 @@ function process_gruntdiff($line) {
         $output.= '<error line="0" column="0" severity="error" ';
         $output.= 'message="'. s($error) .'"/>' . PHP_EOL;
         $output.= '</file>';
-    }
+    } else if (preg_match('/^Warning: (.*)$/', $line, $matches)) {
+        // This is a warning coming directly from grunt output.
+        $warning = $matches[1];
 
+        $output.= '<file name="">' . PHP_EOL;
+        $output.= '<error line="0" column="0" severity="warning" ';
+        $output.= 'message="'. s($warning) .'"/>' . PHP_EOL;
+        $output.= '</file>';
+    }
     return $output;
 }
 

--- a/tests/02-checkstyle_manipulations.bats
+++ b/tests/02-checkstyle_manipulations.bats
@@ -41,6 +41,10 @@ assert_checkstyle() {
     assert_checkstyle 'remote_branch_checker/checkstyle_converter.php --format=gruntdiff' grunt.txt grunt.xml
 }
 
+@test "remote_branch_checker/checkstyle_converter.php: grunt build failed" {
+    assert_checkstyle 'remote_branch_checker/checkstyle_converter.php --format=gruntdiff' grunt-build-failed.txt grunt-build-failed.xml
+}
+
 @test "remote_branch_checker/checkstyle_converter.php: shifter" {
     assert_checkstyle 'remote_branch_checker/checkstyle_converter.php --format=shifter' grunt-errors.txt shifter.xml
 }

--- a/tests/99-remote_branch_checker.bats
+++ b/tests/99-remote_branch_checker.bats
@@ -64,7 +64,7 @@ assert_prechecker () {
 @test "remote_branch_checker/remote_branch_checker.sh: all possible checks failing" {
     # from https://integration.moodle.org/job/Precheck%20remote%20branch/26024/
     assert_prechecker MDL-53136-master-dc60e4f MDL-53136 d1a3ea62ef79f2d4d997e329a647535340ef15db \
-    "smurf,error,14,6:phplint,error,1,0;phpcs,error,2,2;js,error,2,1;css,error,1,1;phpdoc,success,0,0;commit,error,1,1;savepoint,error,2,0;thirdparty,warning,0,1;grunt,error,5,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+    "smurf,error,15,6:phplint,error,1,0;phpcs,error,2,2;js,error,2,1;css,error,1,1;phpdoc,success,0,0;commit,error,1,1;savepoint,error,2,0;thirdparty,warning,0,1;grunt,error,6,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: all checks passing" {

--- a/tests/99-remote_branch_checker.bats
+++ b/tests/99-remote_branch_checker.bats
@@ -110,3 +110,8 @@ assert_prechecker () {
     assert_prechecker fixture-mustache-lint-js MDL-12345 cad8adccc796f40ab11b1236cd637e9b987c17c8 \
     "smurf,warning,0,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,warning,0,2"
 }
+
+@test "remote_branch_checker/remote_branch_checker.sh: grunt build failed" {
+    assert_prechecker fixture-grunt-build-failed MDL-12345 cd4a6b8b0bca159d3abb1468794ed5a074c5b701 \
+    "smurf,error,2,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,1,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+}

--- a/tests/99-remote_branch_checker.bats
+++ b/tests/99-remote_branch_checker.bats
@@ -58,7 +58,7 @@ assert_prechecker () {
 @test "remote_branch_checker/remote_branch_checker.sh: old branch failing" {
     # An extremely old branch running jshint..
     assert_prechecker local_ci_fixture_oldbranch MDLSITE-3899 b3f5865eabbbdd439ac7f2ec763046f2ac7f0b37 \
-    "smurf,error,3,6:phplint,success,0,0;phpcs,success,0,0;js,warning,0,6;css,success,0,0;phpdoc,success,0,0;commit,error,3,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+    "smurf,error,4,7:phplint,success,0,0;phpcs,success,0,0;js,warning,0,6;css,success,0,0;phpdoc,success,0,0;commit,error,3,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: all possible checks failing" {
@@ -75,7 +75,7 @@ assert_prechecker () {
 
 @test "remote_branch_checker/remote_branch_checker.sh: stylelint checks" {
     assert_prechecker prechecker-fixture-stylelint MDL-12345 7752762674c1211e00c5d24045c065c41f5bc662 \
-    "smurf,error,3,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,3,1;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+    "smurf,error,4,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,3,1;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: all results reported despite no php/js/css files" {

--- a/tests/fixtures/checkstyle/grunt-build-failed.txt
+++ b/tests/fixtures/checkstyle/grunt-build-failed.txt
@@ -1,0 +1,12 @@
+Running "startup" task
+
+Running "stylelint:scss" (stylelint) task
+>> Linted 117 files without errors
+
+Running "stylelint:less" (stylelint) task
+>> theme/bootstrapbase/less/moodle/modules.less
+>>  15:1  ✖  Expected indentation of 4 spaces   indentation
+Warning: Task "stylelint:less" failed. Use --force to continue.
+
+Aborted due to warnings.
+ERROR: Problems running grunt

--- a/tests/fixtures/checkstyle/grunt-build-failed.xml
+++ b/tests/fixtures/checkstyle/grunt-build-failed.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="1.3.2">
 <file name="">
+<error line="0" column="0" severity="warning" message="Task &quot;stylelint:less&quot; failed. Use --force to continue."/>
+</file><file name="">
 <error line="0" column="0" severity="error" message="Problems running grunt"/>
 </file></checkstyle>

--- a/tests/fixtures/checkstyle/grunt-build-failed.xml
+++ b/tests/fixtures/checkstyle/grunt-build-failed.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="1.3.2">
+<file name="">
+<error line="0" column="0" severity="error" message="Problems running grunt"/>
+</file></checkstyle>

--- a/tests/fixtures/checkstyle/grunt.xml
+++ b/tests/fixtures/checkstyle/grunt.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="1.3.2">
-<file name="/var/lib/jenkins/git_repositories/prechecker/lib/editor/atto/yui/build/editor/js/autosave.min.js">
+<file name="">
+<error line="0" column="0" severity="error" message="Some modules are not properly processed by grunt. Changes detected:"/>
+</file><file name="/var/lib/jenkins/git_repositories/prechecker/lib/editor/atto/yui/build/editor/js/autosave.min.js">
 <error line="0" column="0" severity="error" message="Uncommitted change detected."/>
 </file><file name="/var/lib/jenkins/git_repositories/prechecker/lib/yui/build/event/js/event.min.js">
 <error line="0" column="0" severity="error" message="Uncommitted change detected."/>

--- a/tests/fixtures/remote_branch_checker/MDL-53136-master-dc60e4f.xml
+++ b/tests/fixtures/remote_branch_checker/MDL-53136-master-dc60e4f.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<smurf version="0.9.1" numerrors="14" numwarnings="6">
-  <summary status="error" numerrors="14" numwarnings="6" condensedresult="smurf,error,14,6:phplint,error,1,0;phpcs,error,2,2;js,error,2,1;css,error,1,1;phpdoc,success,0,0;commit,error,1,1;savepoint,error,2,0;thirdparty,warning,0,1;grunt,error,5,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0">
+<smurf version="0.9.1" numerrors="15" numwarnings="6">
+  <summary status="error" numerrors="15" numwarnings="6" condensedresult="smurf,error,15,6:phplint,error,1,0;phpcs,error,2,2;js,error,2,1;css,error,1,1;phpdoc,success,0,0;commit,error,1,1;savepoint,error,2,0;thirdparty,warning,0,1;grunt,error,6,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0">
     <detail name="phplint" status="error" numerrors="1" numwarnings="0"/>
     <detail name="phpcs" status="error" numerrors="2" numwarnings="2"/>
     <detail name="js" status="error" numerrors="2" numwarnings="1"/>
@@ -9,7 +9,7 @@
     <detail name="commit" status="error" numerrors="1" numwarnings="1"/>
     <detail name="savepoint" status="error" numerrors="2" numwarnings="0"/>
     <detail name="thirdparty" status="warning" numerrors="0" numwarnings="1"/>
-    <detail name="grunt" status="error" numerrors="5" numwarnings="0"/>
+    <detail name="grunt" status="error" numerrors="6" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
@@ -128,9 +128,14 @@
       </problem>
     </mess>
   </check>
-  <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="5" numwarnings="0" allowfiltering="0">
+  <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="6" numwarnings="0" allowfiltering="0">
     <description>This section shows files built by grunt and not commited</description>
     <mess>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/dc60e4fd400937e7f7fd13dfabfb293c86dc7129/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
+        <message>Some modules are not properly processed by grunt. Changes detected:</message>
+        <description/>
+        <code/>
+      </problem>
       <problem file="lib/yui/build/moodle-core-dock/moodle-core-dock-debug.js" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/dc60e4fd400937e7f7fd13dfabfb293c86dc7129/lib/yui/build/moodle-core-dock/moodle-core-dock-debug.js#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
         <message>Uncommitted change detected.</message>
         <description/>

--- a/tests/fixtures/remote_branch_checker/fixture-grunt-build-failed.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-grunt-build-failed.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<smurf version="0.9.1" numerrors="2" numwarnings="1">
+  <summary status="error" numerrors="2" numwarnings="1" condensedresult="smurf,error,2,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,1,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0">
+    <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="js" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="css" status="error" numerrors="1" numwarnings="0"/>
+    <detail name="phpdoc" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="grunt" status="error" numerrors="1" numwarnings="1"/>
+    <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
+  </summary>
+  <check id="phplint" title="PHP lint problems" url="http://php.net/docs.php" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows php lint problems in the code detected by php -l</description>
+    <mess/>
+  </check>
+  <check id="phpcs" title="PHP coding style problems" url="https://docs.moodle.org/dev/Coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the coding style problems detected in the code by phpcs</description>
+    <mess/>
+  </check>
+  <check id="js" title="Javascript coding style problems" url="https://docs.moodle.org/dev/Javascript/Coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the coding style problems detected in the code by eslint</description>
+    <mess/>
+  </check>
+  <check id="css" title="CSS problems" url="https://docs.moodle.org/dev/CSS_coding_style" numerrors="1" numwarnings="0" allowfiltering="1">
+    <description>This section shows CSS problems detected by stylelint</description>
+    <mess>
+      <problem file="theme/boost/scss/moodle/icons.scss" linefrom="11" lineto="11" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/bd1e8a01cf920bc79e7ca80949f6a3f41db8c8e2/theme/boost/scss/moodle/icons.scss#L11" ruleset="stylelint" rule="rules.property-no-unknown" url="https://docs.moodle.org/dev/CSS_coding_style" type="error" weight="5">
+        <message>Unexpected unknown property "some-unknown-css" (property-no-unknown)</message>
+        <description/>
+        <code/>
+      </problem>
+    </mess>
+  </check>
+  <check id="phpdoc" title="PHPDocs style problems" url="https://docs.moodle.org/dev/Coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the phpdocs problems detected in the code by local_moodlecheck</description>
+    <mess/>
+  </check>
+  <check id="commit" title="Commit messages problems" url="https://docs.moodle.org/dev/Commit_cheat_sheet#Provide_clear_commit_messages" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the problems detected in the commit messages by the commits checker</description>
+    <mess/>
+  </check>
+  <check id="savepoint" title="Update savepoints problems" url="https://docs.moodle.org/dev/Upgrade_API" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows problems detected with the handling of upgrade savepoints</description>
+    <mess/>
+  </check>
+  <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="1" numwarnings="1" allowfiltering="0">
+    <description>This section shows files built by grunt and not commited</description>
+    <mess>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/bd1e8a01cf920bc79e7ca80949f6a3f41db8c8e2/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="warning" weight="1">
+        <message>Task "stylelint:scss" failed. Use --force to continue.</message>
+        <description/>
+        <code/>
+      </problem>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/bd1e8a01cf920bc79e7ca80949f6a3f41db8c8e2/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
+        <message>Problems running grunt</message>
+        <description/>
+        <code/>
+      </problem>
+    </mess>
+  </check>
+  <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows problems detected by shifter</description>
+    <mess/>
+  </check>
+  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section reports issues detected by Travis CI.</description>
+    <mess/>
+  </check>
+  <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows problems detected in mustache templates</description>
+    <mess/>
+  </check>
+</smurf>

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_oldbranch.xml
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_oldbranch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<smurf version="0.9.1" numerrors="3" numwarnings="6">
-  <summary status="error" numerrors="3" numwarnings="6" condensedresult="smurf,error,3,6:phplint,success,0,0;phpcs,success,0,0;js,warning,0,6;css,success,0,0;phpdoc,success,0,0;commit,error,3,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0">
+<smurf version="0.9.1" numerrors="4" numwarnings="7">
+  <summary status="error" numerrors="4" numwarnings="7" condensedresult="smurf,error,4,7:phplint,success,0,0;phpcs,success,0,0;js,warning,0,6;css,success,0,0;phpdoc,success,0,0;commit,error,3,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="warning" numerrors="0" numwarnings="6"/>
@@ -9,7 +9,7 @@
     <detail name="commit" status="error" numerrors="3" numwarnings="0"/>
     <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="grunt" status="error" numerrors="1" numwarnings="1"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
@@ -93,9 +93,20 @@
     <description>This section shows problems detected with the modification of third party libraries</description>
     <mess/>
   </check>
-  <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="0" numwarnings="0" allowfiltering="0">
+  <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="1" numwarnings="1" allowfiltering="0">
     <description>This section shows files built by grunt and not commited</description>
-    <mess/>
+    <mess>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/8b0f63da1743bd175115ea9e07d298dd19500f9b/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="warning" weight="1">
+        <message>Task "jshint:files" failed. Use --force to continue.</message>
+        <description/>
+        <code/>
+      </problem>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/8b0f63da1743bd175115ea9e07d298dd19500f9b/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
+        <message>Problems running grunt</message>
+        <description/>
+        <code/>
+      </problem>
+    </mess>
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>

--- a/tests/fixtures/remote_branch_checker/prechecker-fixture-stylelint.xml
+++ b/tests/fixtures/remote_branch_checker/prechecker-fixture-stylelint.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<smurf version="0.9.1" numerrors="3" numwarnings="1">
-  <summary status="error" numerrors="3" numwarnings="1" condensedresult="smurf,error,3,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,3,1;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0">
+<smurf version="0.9.1" numerrors="4" numwarnings="2">
+  <summary status="error" numerrors="4" numwarnings="2" condensedresult="smurf,error,4,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,3,1;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -9,7 +9,7 @@
     <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
     <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="grunt" status="error" numerrors="1" numwarnings="1"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
@@ -67,9 +67,20 @@
     <description>This section shows problems detected with the modification of third party libraries</description>
     <mess/>
   </check>
-  <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="0" numwarnings="0" allowfiltering="0">
+  <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="1" numwarnings="1" allowfiltering="0">
     <description>This section shows files built by grunt and not commited</description>
-    <mess/>
+    <mess>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/37d67b299413134f176df1c42a8084a726e9a4dd/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="warning" weight="1">
+        <message>Task "stylelint:less" failed. Use --force to continue.</message>
+        <description/>
+        <code/>
+      </problem>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/37d67b299413134f176df1c42a8084a726e9a4dd/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
+        <message>Problems running grunt</message>
+        <description/>
+        <code/>
+      </problem>
+    </mess>
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>


### PR DESCRIPTION
Previously the prechecker was only reporting on undetected changes in files from grunt. This makes it report on grunt failures. 