### PR TITLE
MDLSITE-4625 take #2 : Don't show the "heading error", detailed changes are better

### DIFF
--- a/grunt_process/grunt_process.sh
+++ b/grunt_process/grunt_process.sh
@@ -96,7 +96,7 @@ if [[ -z ${changes} ]]; then
     exit 0
 else
     echo | tee -a "${outputfile}"
-    echo "ERROR: Some modules are not properly processed by grunt. Changes detected:" | tee -a "${outputfile}"
+    echo "WARN: Some modules are not properly processed by grunt. Changes detected:" | tee -a "${outputfile}"
     echo | tee -a "${outputfile}"
     for filename in ${changes} ; do
         fullpath=$gitdir/$filename

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -372,7 +372,7 @@ find ${WORKSPACE} -type f -and -not \( -path "*/.git/*" -or -path "*/work/*" \) 
     grep -vf ${WORKSPACE}/work/patchset.files | xargs -I{} rm {}
 
 # Remove all the empty dirs remaining, but .git and work
-find ${WORKSPACE} -type d -depth -empty -and -not \( -name .git -or -name work \) -delete
+find ${WORKSPACE} -depth -empty -type d -and -not \( -name .git -or -name work \) -delete
 
 # ########## ########## ########## ##########
 

--- a/tests/1-grunt_process.bats
+++ b/tests/1-grunt_process.bats
@@ -25,7 +25,7 @@ setup () {
     # Assert result
     assert_failure
     assert_output --partial "Done, without errors." # Grunt shouldn't have an issue here.
-    assert_output --partial "ERROR: Some modules are not properly processed by grunt. Changes detected:"
+    assert_output --partial "WARN: Some modules are not properly processed by grunt. Changes detected:"
     assert_output --regexp "GRUNT-CHANGE: (.*)/theme/bootstrapbase/style/moodle.css"
 }
 
@@ -39,7 +39,7 @@ setup () {
     # Assert result
     assert_failure
     assert_output --partial "Done, without errors." # Grunt shouldn't have an issue here.
-    assert_output --partial "ERROR: Some modules are not properly processed by grunt. Changes detected:"
+    assert_output --partial "WARN: Some modules are not properly processed by grunt. Changes detected:"
     assert_output --regexp "GRUNT-CHANGE: (.*)/lib/amd/build/url.min.js"
 }
 
@@ -56,6 +56,6 @@ setup () {
 
     # Assert result
     assert_failure
-    assert_output --partial "ERROR: Some modules are not properly processed by grunt. Changes detected:"
+    assert_output --partial "WARN: Some modules are not properly processed by grunt. Changes detected:"
     assert_output --regexp "GRUNT-CHANGE: (.*)/.eslintignore"
 }

--- a/tests/2-remote_branch_checker.bats
+++ b/tests/2-remote_branch_checker.bats
@@ -64,7 +64,7 @@ assert_prechecker () {
 @test "remote_branch_checker/remote_branch_checker.sh: all possible checks failing" {
     # from https://integration.moodle.org/job/Precheck%20remote%20branch/26024/
     assert_prechecker MDL-53136-master-dc60e4f MDL-53136 d1a3ea62ef79f2d4d997e329a647535340ef15db \
-    "smurf,error,15,6:phplint,error,1,0;phpcs,error,2,2;js,error,2,1;css,error,1,1;phpdoc,success,0,0;commit,error,1,1;savepoint,error,2,0;thirdparty,warning,0,1;grunt,error,6,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+    "smurf,error,14,6:phplint,error,1,0;phpcs,error,2,2;js,error,2,1;css,error,1,1;phpdoc,success,0,0;commit,error,1,1;savepoint,error,2,0;thirdparty,warning,0,1;grunt,error,5,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: all checks passing" {

--- a/tests/fixtures/checkstyle/grunt.txt
+++ b/tests/fixtures/checkstyle/grunt.txt
@@ -30,7 +30,7 @@ Running "ignorefiles" task
 
 Done.
 
-ERROR: Some modules are not properly processed by grunt. Changes detected:
+WARN: Some modules are not properly processed by grunt. Changes detected:
 
 GRUNT-CHANGE: /var/lib/jenkins/git_repositories/prechecker/lib/editor/atto/yui/build/editor/js/autosave.min.js
 GRUNT-CHANGE: /var/lib/jenkins/git_repositories/prechecker/lib/yui/build/event/js/event.min.js

--- a/tests/fixtures/checkstyle/grunt.xml
+++ b/tests/fixtures/checkstyle/grunt.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="1.3.2">
-<file name="">
-<error line="0" column="0" severity="error" message="Some modules are not properly processed by grunt. Changes detected:"/>
-</file><file name="/var/lib/jenkins/git_repositories/prechecker/lib/editor/atto/yui/build/editor/js/autosave.min.js">
+<file name="/var/lib/jenkins/git_repositories/prechecker/lib/editor/atto/yui/build/editor/js/autosave.min.js">
 <error line="0" column="0" severity="error" message="Uncommitted change detected."/>
 </file><file name="/var/lib/jenkins/git_repositories/prechecker/lib/yui/build/event/js/event.min.js">
 <error line="0" column="0" severity="error" message="Uncommitted change detected."/>

--- a/tests/fixtures/remote_branch_checker/MDL-53136-master-dc60e4f.xml
+++ b/tests/fixtures/remote_branch_checker/MDL-53136-master-dc60e4f.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<smurf version="0.9.1" numerrors="15" numwarnings="6">
-  <summary status="error" numerrors="15" numwarnings="6" condensedresult="smurf,error,15,6:phplint,error,1,0;phpcs,error,2,2;js,error,2,1;css,error,1,1;phpdoc,success,0,0;commit,error,1,1;savepoint,error,2,0;thirdparty,warning,0,1;grunt,error,6,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0">
+<smurf version="0.9.1" numerrors="14" numwarnings="6">
+  <summary status="error" numerrors="14" numwarnings="6" condensedresult="smurf,error,14,6:phplint,error,1,0;phpcs,error,2,2;js,error,2,1;css,error,1,1;phpdoc,success,0,0;commit,error,1,1;savepoint,error,2,0;thirdparty,warning,0,1;grunt,error,5,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0">
     <detail name="phplint" status="error" numerrors="1" numwarnings="0"/>
     <detail name="phpcs" status="error" numerrors="2" numwarnings="2"/>
     <detail name="js" status="error" numerrors="2" numwarnings="1"/>
@@ -9,7 +9,7 @@
     <detail name="commit" status="error" numerrors="1" numwarnings="1"/>
     <detail name="savepoint" status="error" numerrors="2" numwarnings="0"/>
     <detail name="thirdparty" status="warning" numerrors="0" numwarnings="1"/>
-    <detail name="grunt" status="error" numerrors="6" numwarnings="0"/>
+    <detail name="grunt" status="error" numerrors="5" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
@@ -128,14 +128,9 @@
       </problem>
     </mess>
   </check>
-  <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="6" numwarnings="0" allowfiltering="0">
+  <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="5" numwarnings="0" allowfiltering="0">
     <description>This section shows files built by grunt and not commited</description>
     <mess>
-      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/dc60e4fd400937e7f7fd13dfabfb293c86dc7129/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
-        <message>Some modules are not properly processed by grunt. Changes detected:</message>
-        <description/>
-        <code/>
-      </problem>
       <problem file="lib/yui/build/moodle-core-dock/moodle-core-dock-debug.js" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/dc60e4fd400937e7f7fd13dfabfb293c86dc7129/lib/yui/build/moodle-core-dock/moodle-core-dock-debug.js#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
         <message>Uncommitted change detected.</message>
         <description/>


### PR DESCRIPTION
This is a followup of #158 , where we started to report "ERROR". But there was an "ERROR" that was just the heading for the "GRUNT-CHANGE" problems reported.

This is about to change the ERROR to WARN so it's not reported anymore, because GRUNT-CHANGE are enough and better (detailed).

This also fixes a minor recurrent warning with recent gnu find versions. An of course amends related tests.

Ciao :-)