### PR TITLE
NOBUG: remove the SMURFRESULT assertion from prechecker tests

### DIFF
--- a/tests/2-remote_branch_checker.bats
+++ b/tests/2-remote_branch_checker.bats
@@ -35,7 +35,6 @@ assert_prechecker () {
     export branch=$1
     export issue=$2
     export resettocommit=$3
-    shortsummary=$4
 
     smurfxmlfixture=$BATS_TEST_DIRNAME/fixtures/remote_branch_checker/$branch.xml
 
@@ -50,68 +49,55 @@ assert_prechecker () {
 
     ci_run remote_branch_checker/remote_branch_checker.sh
     assert_success
-    assert_output --partial "SMURFRESULT: $shortsummary"
-
     assert_files_same $smurfxmlfixture $WORKSPACE/work/smurf.xml
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: old branch failing" {
     # An extremely old branch running jshint..
-    assert_prechecker local_ci_fixture_oldbranch MDLSITE-3899 b3f5865eabbbdd439ac7f2ec763046f2ac7f0b37 \
-    "smurf,error,4,7:phplint,success,0,0;phpcs,success,0,0;js,warning,0,6;css,success,0,0;phpdoc,success,0,0;commit,error,3,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+    assert_prechecker local_ci_fixture_oldbranch MDLSITE-3899 b3f5865eabbbdd439ac7f2ec763046f2ac7f0b37
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: all possible checks failing" {
     # from https://integration.moodle.org/job/Precheck%20remote%20branch/26024/
-    assert_prechecker MDL-53136-master-dc60e4f MDL-53136 d1a3ea62ef79f2d4d997e329a647535340ef15db \
-    "smurf,error,14,6:phplint,error,1,0;phpcs,error,2,2;js,error,2,1;css,error,1,1;phpdoc,success,0,0;commit,error,1,1;savepoint,error,2,0;thirdparty,warning,0,1;grunt,error,5,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+    assert_prechecker MDL-53136-master-dc60e4f MDL-53136 d1a3ea62ef79f2d4d997e329a647535340ef15db
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: all checks passing" {
     # from https://integration.moodle.org/job/Precheck%20remote%20branch/25996/
-    assert_prechecker MDL-53572-master-8ce58c9 MDL-53572 d1a3ea62ef79f2d4d997e329a647535340ef15db \
-    "smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+    assert_prechecker MDL-53572-master-8ce58c9 MDL-53572 d1a3ea62ef79f2d4d997e329a647535340ef15db
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: stylelint checks" {
-    assert_prechecker prechecker-fixture-stylelint MDL-12345 7752762674c1211e00c5d24045c065c41f5bc662 \
-    "smurf,error,4,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,3,1;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+    assert_prechecker prechecker-fixture-stylelint MDL-12345 7752762674c1211e00c5d24045c065c41f5bc662
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: all results reported despite no php/js/css files" {
     # Ensure we always report each section, even if there are no php/css/js files to check
-    assert_prechecker fixture-non-code-update MDL-12345 6f302b17b97078059d4f02d747abf5822a064e87 \
-    "smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+    assert_prechecker fixture-non-code-update MDL-12345 6f302b17b97078059d4f02d747abf5822a064e87
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: thirdparty css modification" {
     # Ensure stylelint doesn't complain about the third party css, but thirdpart does
     # TODO: thirdparty check bug with reporting same file twice..
-    assert_prechecker fixture-thirdparty-css MDL-12345 6f302b17b97078059d4f02d747abf5822a064e87 \
-    "smurf,warning,0,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,warning,0,2;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+    assert_prechecker fixture-thirdparty-css MDL-12345 6f302b17b97078059d4f02d747abf5822a064e87
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: bad amos script" {
-    assert_prechecker fixture-bad-amos-commands MDL-12345 6f302b17b97078059d4f02d747abf5822a064e87 \
-    "smurf,error,2,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,error,2,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+    assert_prechecker fixture-bad-amos-commands MDL-12345 6f302b17b97078059d4f02d747abf5822a064e87
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: good amos commands" {
-    assert_prechecker fixture-good-amos-commit MDL-12345 6f302b17b97078059d4f02d747abf5822a064e87 \
-    "smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+    assert_prechecker fixture-good-amos-commit MDL-12345 6f302b17b97078059d4f02d747abf5822a064e87
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: mustache lint" {
-    assert_prechecker fixture-mustache-lint MDL-12345 d9520bc04e4d47d8dedfbe6b07cbbe0cb14c7fcf \
-    "smurf,error,1,4:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,error,1,4"
+    assert_prechecker fixture-mustache-lint MDL-12345 d9520bc04e4d47d8dedfbe6b07cbbe0cb14c7fcf
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: mustache lint eslint problem" {
-    assert_prechecker fixture-mustache-lint-js MDL-12345 cad8adccc796f40ab11b1236cd637e9b987c17c8 \
-    "smurf,warning,0,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,warning,0,2"
+    assert_prechecker fixture-mustache-lint-js MDL-12345 cad8adccc796f40ab11b1236cd637e9b987c17c8
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: grunt build failed" {
-    assert_prechecker fixture-grunt-build-failed MDL-12345 cd4a6b8b0bca159d3abb1468794ed5a074c5b701 \
-    "smurf,error,2,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,1,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0"
+    assert_prechecker fixture-grunt-build-failed MDL-12345 cd4a6b8b0bca159d3abb1468794ed5a074c5b701
 }


### PR DESCRIPTION
The problem is that when we assert the smurf result in the console
output we are just duplicating the assertion which is already happening
by comparing the .xml file. But because we fail before looking at the xml
file we don't get to see how the output differs.. which means in the
case of random travis errors it makes it hard for us to diagnose what
the problem is.

Probably best just to remove that duplciated assertion and hopefully
we'll be able to more easily work out whats going on in case of
failures.