### PR TITLE
MDLSITE-4808 prechecker: Inform to other jobs about checked issues

### DIFF
--- a/tracker_automations/bulk_precheck_issues/bulk_precheck_issues.sh
+++ b/tracker_automations/bulk_precheck_issues/bulk_precheck_issues.sh
@@ -8,6 +8,7 @@
 #cf_branches: pairs of moodle branch and id for "Pull XXXX Branch" custom field (master:customfield_10111,....)
 #cf_testinginstructions: id for testing instructions custom field (customfield_10117)
 #criteria: "awaiting peer review", "awaiting integration", "developer request"
+#informtofiles: comma separated list of files where each MDL processed will be informed (format MDL-xxxx unixseconds)
 #$maxcommitswarn: Max number of commits accepted per run. Warning if exceeded. Defaults to 10.
 #$maxcommitserror: Max number of commits accepted per run. Error if exceeded. Defaults to 100.
 #quiet: if enabled ("true"), don't perform any action in the Tracker.
@@ -287,4 +288,18 @@ while read issue; do
         echo "  - Sending results to the Tracker"
         . "${mydir}/criteria/${criteria}/postissue.sh"
     fi
+
+    # Inform to configured files about the processing of the MDL-xxxxx happenend
+    if [[ -n $informtofiles ]]; then
+        echo "  - Informing about the execution via files"
+        for informtofile in "${informtofiles//,/ }"; do
+            if [[ -w "${informtofile}" ]]; then
+                echo "    - ${informtofile} updated"
+                echo ${issue} $(date +%s) bulk_precheck_issues >> "${informtofile}"
+            else
+                echo "    - ${informtofile} NOT updated (not found/not writable)"
+            fi
+        done
+    fi
+
 done < "${resultfile}"

--- a/tracker_automations/remove_ci_label_from_waiting_integration/remove_ci_label_from_waiting_integration.sh
+++ b/tracker_automations/remove_ci_label_from_waiting_integration/remove_ci_label_from_waiting_integration.sh
@@ -54,7 +54,7 @@ for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
     if [[ -r "${lastfile}" ]]; then
         linefound=$(grep "${issue}" "${lastfile}" | tail -1)
         if [[ -n $linefound ]]; then
-            timefound="${linefound##* }"
+            timefound=$(echo "${linefound}" | cut -d' ' -f2)
             secondsago=$(($now - $timefound))
             echo "    - 'ci' label was removed $secondsago ago"
             if [[ $secondsago -le 3600 ]]; then
@@ -78,13 +78,15 @@ done
 # it will match the conditions above anymore.
 if [[ -r "${lastfile}" ]]; then
     lastline=$(tail -1 "${lastfile}")
-    lasttime="${lastline##* }"
-    secondsago=$(($now - $lasttime))
-    if [[ $secondsago -gt 3600 ]]; then
-        rm -fr "${lastfile}"
-        echo "Cleaning outdated latest results"
-    else
-        echo "Keeping meaningful latest results"
+    if [[ -n $lastline ]]; then
+        lasttime=$(echo "${lastline}" | cut -d' ' -f2)
+        secondsago=$(($now - $lasttime))
+        if [[ $secondsago -gt 3600 ]]; then
+            > "${lastfile}" # just reset it so it's always available for notifications from others.
+            echo "Cleaning outdated latest results"
+        else
+            echo "Keeping meaningful latest results"
+        fi
     fi
 fi
 


### PR DESCRIPTION
With a new optional parameter, informtofiles, where a list of
files can be specified. The job will write one line to each of those
files with format:

MDL-xxxxxxx  unixtime bulk_precheck_issues

Just that, it's the responsibility of other jobs to read and
process that information properly.