### PR TITLE
NOBUG: Always delete any _precheck branch from previous executions

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -70,6 +70,17 @@ if ! $(git remote -v | grep -q '^integration[[:space:]]]*git:.*integration.git')
     ${gitcmd} remote add integration git://git.moodle.org/integration.git
 fi
 
+# We are into a _precheck branch from previous run. We don't like any leftover
+# so let's delete it drastically. Will be recreated later if needed.
+currentbranch=$(${gitcmd} rev-parse --abbrev-ref HEAD)
+if [[ ${currentbranch} =~ _precheck$ ]]; then
+    echo "Info: Deleting ${currentbranch} branch from previous execution"
+    basebranch=${currentbranch%_precheck}
+    ${gitcmd} reset --hard ${basebranch}
+    ${gitcmd} checkout ${basebranch}
+    ${gitcmd} branch -D ${currentbranch}
+fi
+
 # Now, ensure the repository in completely clean.
 echo "Info: Cleaning worktree"
 ${gitcmd} clean -q -dfx


### PR DESCRIPTION
We cannot delete the _precheck branches while they run because that
will cause all the /work to be lost before being saved as artifacts.

So, on every run, before performing any other git operation, we check
if we are in a _precheck branch and, if so, proceed to checkout its
base counterpart, checkout it and delete the _precheck branch and
any old stuff it may have.

Note this was introduced because we found some plugins having own
.gitattributes files, playing with auto-crlf settings and causing
next executions of the checker to fail forever. Now, we ensure
nothing is left in the prechecker repo from previous executions.