### PR TITLE
MDLSITE-4892 deal with spaces in passed varibles

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -146,6 +146,11 @@ basecommit=$(${gitcmd} rev-parse --verify ${baseref})
 # (NOTE: checkout -B means create if branch doesn't exist or reset if it does.)
 ${gitcmd} checkout -q -B ${integrateto}_precheck $baseref
 
+# Do some cleanup onto the passed details
+
+# Trim whitespace in branch/remote
+remote=${remote//[[:blank:]]/}
+branch=${branch//[[:blank:]]/}
 
 # Fetch the remote branch.
 set +e

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -362,7 +362,7 @@ fi
 
 if [[ -z "${isplugin}" ]]; then
     echo "Info: Running travis..."
-    ${phpcmd} ${mydir}/../travis/check_branch_status.php --repository=$remote --branch=$branch > "${WORKSPACE}/work/travis.txt"
+    ${phpcmd} ${mydir}/../travis/check_branch_status.php --repository="$remote" --branch="$branch" > "${WORKSPACE}/work/travis.txt"
     cat "${WORKSPACE}/work/travis.txt" | ${phpcmd} ${mydir}/checkstyle_converter.php --format=travis > "${WORKSPACE}/work/travis.xml"
 fi
 

--- a/tests/2-remote_branch_checker.bats
+++ b/tests/2-remote_branch_checker.bats
@@ -101,3 +101,16 @@ assert_prechecker () {
 @test "remote_branch_checker/remote_branch_checker.sh: grunt build failed" {
     assert_prechecker fixture-grunt-build-failed MDL-12345 cd4a6b8b0bca159d3abb1468794ed5a074c5b701
 }
+
+@test "remote_branch_checker/remote_branch_checker.sh: remote which doesnt exist" {
+    export branch="a-branch-which-will-never-exist"
+    export issue="MDL-12345"
+    export integrateto=master
+    export rebaseerror=9999
+    export remote=https://git.in.moodle.com/integration/prechecker.git
+    export extrapath=.
+
+    ci_run remote_branch_checker/remote_branch_checker.sh
+    assert_failure
+    assert_output --partial "Unable to fetch information from a-branch-which-will-never-exist branch"
+}


### PR DESCRIPTION
Because this comes from tracker fields, we can trim the spaces. Probably
would be more appropiate in the remote branch checker, but its better
covered with tests here and doesn't do any harm.

I decided not to add a testcase for the 'ok with space' case to avoid
wasting the time of a full precheck run.