### PR TITLE
MDLSITE-5134 ci: moving to nvm nodejs manager

### DIFF
--- a/grunt_process/grunt_process.sh
+++ b/grunt_process/grunt_process.sh
@@ -3,7 +3,7 @@
 # $gitdir: Directory containing git repo
 # $gitbranch: Branch we are going to install the DB
 # $extrapath: Extra paths to be available (global)
-# $npmcmd: Path to the npm executable (global)
+# $npmcmd: Optional, path to the npm executable (global)
 # $npmbase: (optional) Base directory where we'll store multiple npm packages versions (subdirectories per branch)
 
 # Let's be strict. Any problem leads to failure.
@@ -14,7 +14,7 @@ if [[ -n ${extrapath} ]]; then
     export PATH=${PATH}:${extrapath}
 fi
 
-required="WORKSPACE gitdir gitbranch extrapath npmcmd"
+required="WORKSPACE gitdir gitbranch extrapath"
 for var in $required; do
     if [ -z "${!var}" ]; then
         echo "Error: ${var} environment variable is not defined. See the script comments."
@@ -28,6 +28,8 @@ outputfile=${WORKSPACE}/grunt_process.txt
 # calculate some variables
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# Apply some defaults.
+npmcmd=${npmcmd:-npm}
 
 cd ${gitdir}
 rm -fr config.php

--- a/less_checker/less_checker.sh
+++ b/less_checker/less_checker.sh
@@ -4,7 +4,7 @@
 # $gitbranch: Branch we are going to verify
 # $extrapath: Extra paths to be available (global)
 # $gitcmd: Path to the git executable (global)
-# $npmcmd: Path to the npm executable (global)
+# $npmcmd: Optional, path to the npm executable (global)
 # $recessbase: Base directory where we'll store multiple recess versions (can be different by branch)
 # $recessversion: (optional) Version of recess to be used by this job
 
@@ -12,7 +12,7 @@
 set -e
 
 # Verify everything is set
-required="WORKSPACE gitdir gitbranch extrapath gitcmd npmcmd recessbase"
+required="WORKSPACE gitdir gitbranch extrapath gitcmd recessbase"
 for var in ${required}; do
     if [ -z "${!var}" ]; then
         echo "Error: ${var} environment variable is not defined. See the script comments."
@@ -30,6 +30,9 @@ outputfile=${WORKSPACE}/less_checker.txt
 
 # calculate some variables
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Apply some defaults.
+npmcmd=${npmcmd:-npm}
 
 # Ensure git is ready
 cd ${gitdir} && ${gitcmd} reset --hard ${gitbranch}

--- a/prepare_npm_stuff/prepare_npm_stuff.sh
+++ b/prepare_npm_stuff/prepare_npm_stuff.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # $gitdir: Directory containing git repo
 # $gitbranch: Branch we are going to install the DB
-# $npmcmd: Path to the npm executable (global)
 # $npmbase: Base directory where we'll store multiple npm packages versions (subdirectories per branch)
 # $nodecmd: Optional, path to the node executable (global)
+# $npmcmd: Optional, path to the npm executable (global)
 # $shifterversion: Optional, defaults to 0.4.6. Not installed if there is a package.json file (present in 29 and up)
 # $recessversion: Optional, defaults to 1.1.9 (Important! it's the only legacy version working. Older ones
 #    lead to empty results). Not installed if there is a package.json file (present in 29 and up)
@@ -11,7 +11,7 @@
 # Let's be strict. Any problem leads to failure.
 set -e
 
-required="gitdir gitbranch npmcmd npmbase"
+required="gitdir gitbranch npmbase"
 for var in $required; do
     if [ -z "${!var}" ]; then
         echo "ERROR: ${var} environment variable is not defined. See the script comments."
@@ -25,12 +25,14 @@ mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Apply some defaults.
 shifterversion=${shifterversion:-0.4.6}
 recessversion=${recessversion:-1.1.9}
+nodecmd=${nodecmd:-node}
+npmcmd=${npmcmd:-npm}
 
 # Print nodejs and npm versions for informative purposes
-if [[ -x ${nodecmd} ]]; then
+if hash ${nodecmd} 2>/dev/null; then
     echo "INFO: node version: $(${nodecmd} --version)"
 fi
-if [[ -x ${npmcmd} ]]; then
+if hash ${npmcmd} 2>/dev/null; then
     echo "INFO: npm  version: $(${npmcmd} --version)"
 fi
 
@@ -71,7 +73,7 @@ if [[ -f ${gitdir}/package.json ]]; then
     gruntcmd="$(${npmcmd} bin)"/grunt
     if [[ ! -f ${gruntcmd} ]]; then
         echo "WARN: grunt-cli executable not found. Installing everything"
-        ${npmcmd} install --no-color grunt-cli
+        ${npmcmd} --no-color --no-save install grunt-cli
     fi
 else
 

--- a/rebase_security/rebase_security.sh
+++ b/rebase_security/rebase_security.sh
@@ -2,7 +2,7 @@
 # $gitcmd: Path to git executable.
 # $gitdir: Directory containing git repo (will be cloned to if .git doesn't exist)
 # $gitbranch: Branch we are rebasing onto
-# $npmcmd: Path to the npm executable (global)
+# $npmcmd: Optional, path to the npm executable (global)
 # $npmbase: Base directory where we'll store multiple npm packages versions (subdirectories per branch)
 # $integrationremote: Remote where integration is being fetched from
 # $securityremote: Remote repo where security branches are being pushed to
@@ -107,12 +107,15 @@ function fix_conflict() {
 }
 
 # Verify everything is set.
-required="gitcmd gitdir gitbranch npmcmd npmbase integrationremote securityremote"
+required="gitcmd gitdir gitbranch npmbase integrationremote securityremote"
 for var in ${required}; do
     if [ -z "${!var}" ]; then
         exit_with_error "Error: ${var} environment variable is not defined. See the script comments."
     fi
 done
+
+# Apply some defaults.
+npmcmd=${npmcmd:-npm}
 
 if [[ ! -d "$gitdir/.git" ]]; then
     info "Doing initial clone of moodle.git, git repo not found"

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -14,7 +14,7 @@
 # $rebasewarn: Max number of days allowed since rebase. Warning if exceeded. Defaults to 20.
 # $rebaseerror: Max number of days allowed since rebase. Error if exceeded. Defaults to 60.
 # $extrapath: Extra paths to be available (global)
-# $npmcmd: Path to the npm executable (global)
+# $npmcmd: Optional, path to the npm executable (global)
 # $npmbase: Base directory where we'll store multiple npm packages versions (subdirectories per branch)
 # $pushremote: (optional) Remote to push the results of prechecker to. Will create branches like MDL-1234-master-shorthash
 # $resettocommit: (optional) Should not be used in production runs. Reset $integrateto to a commit for testing purposes.
@@ -29,6 +29,15 @@ if [[ -n ${extrapath} ]]; then
     export PATH=${PATH}:${extrapath}
 fi
 
+# Verify everything is set
+required="WORKSPACE gitcmd phpcmd jshintcmd csslintcmd remote branch integrateto npmbase issue"
+for var in ${required}; do
+    if [ -z "${!var}" ]; then
+        echo "Error: ${var} environment variable is not defined. See the script comments."
+        exit 1
+    fi
+done
+
 # Apply some defaults
 filtering=${filtering:-true}
 format=${format:-html}
@@ -36,19 +45,11 @@ maxcommitswarn=${maxcommitswarn:-10}
 maxcommitserror=${maxcommitserror:-100}
 rebasewarn=${rebasewarn:-20}
 rebaseerror=${rebaseerror:-60}
+npmcmd=${npmcmd:-npm}
 
 # And reconvert some variables
 export gitdir="${WORKSPACE}"
 export gitbranch="${integrateto}"
-
-# Verify everything is set
-required="WORKSPACE gitcmd phpcmd jshintcmd csslintcmd remote branch integrateto npmcmd npmbase issue"
-for var in ${required}; do
-    if [ -z "${!var}" ]; then
-        echo "Error: ${var} environment variable is not defined. See the script comments."
-        exit 1
-    fi
-done
 
 # Calculate some variables
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/shifter_walk/shifter_walk.sh
+++ b/shifter_walk/shifter_walk.sh
@@ -4,7 +4,7 @@
 # $gitbranch: Branch we are going to install the DB
 # $extrapath: Extra paths to be available (global)
 # $gitcmd: Path to the git executable (global)
-# $npmcmd: Path to the npm executable (global)
+# $npmcmd: Optional, path to the npm executable (global)
 # $shifterbase: Base directory where we'll store multiple shifter versions (can be different by branch)
 # $shifterversion: (optional) Version of shifter to be used by this job
 
@@ -12,7 +12,7 @@
 set +e
 
 # Verify everything is set
-required="WORKSPACE gitdir gitbranch extrapath gitcmd npmcmd shifterbase"
+required="WORKSPACE gitdir gitbranch extrapath gitcmd shifterbase"
 for var in ${required}; do
     if [ -z "${!var}" ]; then
         echo "Error: ${var} environment variable is not defined. See the script comments."
@@ -30,6 +30,9 @@ outputfile=${WORKSPACE}/shifter_walk.txt
 
 # calculate some variables
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Apply some defaults.
+npmcmd=${npmcmd:-npm}
 
 # Ensure git is ready
 cd ${gitdir} && git reset --hard ${gitbranch}

--- a/tests/2-remote_branch_checker.bats
+++ b/tests/2-remote_branch_checker.bats
@@ -11,12 +11,12 @@ prepare_prechecker_npmbins () {
 
     export csslintcmd=$npmglobals/node_modules/.bin/csslint
     if [[ ! -f $csslintcmd ]]; then
-        $npmcmd --silent install csslint
+        npm --silent install csslint
     fi
 
     export jshintcmd=$npmglobals/node_modules/.bin/jshint
     if [[ ! -f $jshintcmd ]]; then
-        $npmcmd --silent install jshint
+        npm --silent install jshint
     fi
     cd $OLDPWD
 }

--- a/tests/libs/shared_setup.bash
+++ b/tests/libs/shared_setup.bash
@@ -34,7 +34,6 @@ export WORKSPACE=$BATS_TMPDIR/workspace
 mkdir -p $WORKSPACE
 export gitcmd=git
 export phpcmd=php
-export npmcmd=npm
 export mysqlcmd=mysql
 export npmbase=$LOCAL_CI_TESTS_CACHEDIR/npmbase
 mkdir -p $npmbase


### PR DESCRIPTION
This does:
- make both npmcmd and nodecmd globals optional,
  defaulting to "npm" and "node" respectively.
  (note there is MDLSITE-4728 about the final
  removal but surely we'll need to branch before
  that happens and delete other old bits like
  shifter/recess)
- better printing the currently used npm/node versions.
- in case grunt-cli needs to be installed explicitly (I've
  tried here with node 4, 6, 7 - npm 2, 3, 5 - and it was
  installed always), it's done with --no-save, so package
  and shrinkwrap files are not modified.
- in prechecker, just moved the mandatory checks before
  applying defaults, to be the same than all other scripts.
- move the 2 "cmds" out from tests as far as they are optional.