### PR TITLE
Detect multiple calls to save point with same version

### DIFF
--- a/check_upgrade_savepoints/check_upgrade_savepoints.php
+++ b/check_upgrade_savepoints/check_upgrade_savepoints.php
@@ -161,6 +161,15 @@ foreach ($files as $file) {
         }
     }
 
+/// Let's ensure there are no duplicate calls to a save point with the same version.
+    if ($count_sp > 0) {
+        foreach (array_count_values($matches2[2]) as $version => $count) {
+            if ($count > 1) {
+                echo "    + ERROR: Detected multiple 'savepoint' calls for version $version".LINEFEED;
+            }
+        }
+    }
+
 /// Let's split them
     if (!preg_match_all('@(' . $if_regexp . '(\{(?>(?>[^{}]+)|(?3))*\}))@is', $contents, $matches)) {
         echo "    + NOTE: cannot find 'if' blocks within the upgrade function" . LINEFEED;
@@ -196,7 +205,7 @@ foreach ($files as $file) {
             echo "    + ERROR: version $version is missing corresponding savepoint call" . LINEFEED;
             $has_version_mismatch = true;
         } else if ($count_spv > 1) {
-            echo "    + WARN: version $version has more than one savepoint call" . LINEFEED;
+            echo "    + ERROR: version $version has more than one savepoint call" . LINEFEED;
             $has_version_mismatch = true;
         } else {
             if ($version !== $matches[2][0]) {

--- a/tests/1-check_upgrade_savepoints.bats
+++ b/tests/1-check_upgrade_savepoints.bats
@@ -27,9 +27,10 @@ setup () {
 
     ci_run check_upgrade_savepoints/check_upgrade_savepoints.sh
     assert_failure
-    run grep WARN $WORKSPACE/check_upgrade_savepoints_MOODLE_31_STABLE.txt
+    run grep -P 'ERROR|WARN' $WORKSPACE/check_upgrade_savepoints_MOODLE_31_STABLE.txt
     assert_output --partial "WARN: Detected less 'if' blocks (92) than 'savepoint' calls (93). Repeated savepoints?"
-    assert_output --partial "WARN: version 2016051700.01 has more than one savepoint call"
+    assert_output --partial "ERROR: Detected multiple 'savepoint' calls for version 2016051700.01"
+    assert_output --partial "ERROR: version 2016051700.01 has more than one savepoint call"
 }
 
 @test "check_upgrade_savepoints/check_upgrade_savepoints.sh: no return statement" {


### PR DESCRIPTION
If a save point is called with the same version, it causes a downgrade error.  This new check looks for duplicate version save point calls throughout the whole upgrade script.

Example of what this catches:
```php
<?php
function xmldb_forum_upgrade($oldversion) {
    if ($oldversion < 2014051201) {
        upgrade_mod_savepoint(true, 2014051201, 'forum');
    }
    if ($oldversion < 2014051201) {
        upgrade_mod_savepoint(true, 2014051201, 'forum');
    }
    return true;
}
```
This causes a downgrade error because you cannot call the save point method with the same or lower version.

This error can be "doubled" up due to the second check that counts the number of save points in each if block.  EG:
```php
<?php
function xmldb_forum_upgrade($oldversion) {
    if ($oldversion < 2014051201) {
        upgrade_mod_savepoint(true, 2014051201, 'forum');
        upgrade_mod_savepoint(true, 2014051201, 'forum');
    }
    return true;
}
```
Would print multiple errors about basically the same thing.  Hopefully that is OK, since downgrade errors are pretty nasty.