### PR TITLE
Ensure a plugin does not upgrade past its defined version

### DIFF
--- a/check_upgrade_savepoints/check_upgrade_savepoints.php
+++ b/check_upgrade_savepoints/check_upgrade_savepoints.php
@@ -208,6 +208,18 @@ foreach ($files as $file) {
     if (!$has_version_mismatch) {
         echo "    + versions in savepoint calls properly matching upgrade blocks" . LINEFEED;
     }
+
+/// Ensure a plugin does not upgrade past its defined version.
+    $versionfile = dirname(dirname($file)).'/version.php';
+    if (file_exists($versionfile)) {
+        if (preg_match('/^\s*\$(module|plugin)->version\s*=\s*([\d.]+)/m', file_get_contents($versionfile), $versionmatches) === 1) {
+            foreach ($versions as $version) {
+                if (((float) $versionmatches[2] * 100) < ((float) $version * 100)) {
+                    echo "    + ERROR: version $version is higher than that defined in $versionfile file".LINEFEED;
+                }
+            }
+        }
+    }
 }
 
     /**

--- a/tests/1-check_upgrade_savepoints.bats
+++ b/tests/1-check_upgrade_savepoints.bats
@@ -77,3 +77,12 @@ setup () {
     run grep ERROR $WORKSPACE/check_upgrade_savepoints_MOODLE_31_STABLE.txt
     assert_output --partial "ERROR: Wrong order in versions: 2014072400 and 2014051201"
 }
+
+@test "check_upgrade_savepoints/check_upgrade_savepoints.sh: savepoint higher than version.php" {
+    git_apply_fixture check_upgrade_savepoints/too_high_savepoint.patch
+
+    ci_run check_upgrade_savepoints/check_upgrade_savepoints.sh
+    assert_failure
+    run grep ERROR $WORKSPACE/check_upgrade_savepoints_MOODLE_31_STABLE.txt
+    assert_output --partial "ERROR: version 2017022300 is higher than that defined in"
+}

--- a/tests/fixtures/check_upgrade_savepoints/too_high_savepoint.patch
+++ b/tests/fixtures/check_upgrade_savepoints/too_high_savepoint.patch
@@ -1,0 +1,30 @@
+From 759377f2f8e235ee37c71f8ac789a4a88444e0c0 Mon Sep 17 00:00:00 2001
+From: "Eloy Lafuente (stronk7)" <stronk7@moodle.org>
+Date: Fri, 29 Sep 2017 00:56:54 +0200
+Subject: [PATCH] Too high versions in savepoints
+
+---
+ mod/assign/db/upgrade.php | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/mod/assign/db/upgrade.php b/mod/assign/db/upgrade.php
+index c0935c5a21..72c5f823ba 100644
+--- a/mod/assign/db/upgrade.php
++++ b/mod/assign/db/upgrade.php
+@@ -200,5 +200,13 @@ function xmldb_assign_upgrade($oldversion) {
+     // Moodle v3.1.0 release upgrade line.
+     // Put any upgrade step following this.
+
++    if ($oldversion < 2017022300) {
++
++        // v3.1.1 is 2016052300, hardly can accept anything higher than that
++
++        // Assign savepoint reached.
++        upgrade_mod_savepoint(true, 2017022300, 'assign');
++    }
++
+     return true;
+ }
+--
+2.14.1
+


### PR DESCRIPTION
This checks to make sure that the versions in the upgrade path are not higher than the version defined in the plugin's version.php file.  If this ever happens, it causes a downgrade error.