### PR TITLE
NOBUG: Grunt to ignore changes caused by 3rd part libs

### DIFF
--- a/grunt_process/grunt_process.sh
+++ b/grunt_process/grunt_process.sh
@@ -4,6 +4,7 @@
 # $gitbranch: Branch we are going to install the DB
 # $npmcmd: Optional, path to the npm executable (global)
 # $npminstall: (optional), if set the script will install nodejs stuff. Else, nodejs managing is external.
+# $isplugin: (optional), if set we are examining a plugin, some exceptions may be applied.
 
 # Let's be strict. Any problem leads to failure.
 set -e
@@ -24,6 +25,7 @@ mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Apply some defaults.
 npmcmd=${npmcmd:-npm}
+isplugin=${isplugin:-}
 
 cd ${gitdir}
 rm -fr config.php
@@ -87,7 +89,12 @@ fi
 
 # Look for changes
 cd ${gitdir}
-changes=$(git ls-files -m)
+gitexclude=
+if [[ -n ${isplugin} ]]; then
+    gitexclude="':(exclude).eslintignore' ':(exclude).stylelintignore'"
+    echo "Checking a plugin, so applying for exclusion (git >= 1.9) with ${gitexclude}"
+fi
+changes=$(git ls-files -m ${gitexclude})
 if [[ -z ${changes} ]]; then
     echo | tee -a "${outputfile}"
     echo "OK: All modules are perfectly processed by grunt" | tee -a "${outputfile}"

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -322,6 +322,7 @@ export initialcommit=${basecommit}
 export GIT_PREVIOUS_COMMIT=${initialcommit}
 export finalcommit=${integrateto}_precheck
 export GIT_COMMIT=${finalcommit}
+export isplugin=${isplugin}
 
 # TODO: Run the db install/upgrade comparison check
 # (only if there is any *install* or *upgrade* file involved)

--- a/tests/1-grunt_process.bats
+++ b/tests/1-grunt_process.bats
@@ -59,3 +59,22 @@ setup () {
     assert_output --partial "WARN: Some modules are not properly processed by grunt. Changes detected:"
     assert_output --regexp "GRUNT-CHANGE: (.*)/.eslintignore"
 }
+
+@test "grunt_process: Uncommited ignorefiles ignored when checking plugin" {
+    # When a 3rd party library is added, but we are checking a 3rd part plugin
+    # we ignore any change in ignorefiles.
+
+    # Testing on in-dev 3.2dev
+    create_git_branch 32-dev 5a1728df39116fc701cc907e85a638aa7674f416
+    git_apply_fixture 32-thirdparty-lib-added.patch
+
+    # Run test
+    export isplugin=1
+    ci_run grunt_process/grunt_process.sh
+
+    # Assert result
+    assert_success
+    assert_output --partial "Running \"ignorefiles\" task"
+    assert_output --partial "Checking a plugin, so applying for exclusion"
+    assert_output --partial "OK: All modules are perfectly processed by grunt"
+}


### PR DESCRIPTION
Some plugins can come with their own 3rd part libs (thirdpartylibs.xml).
That leads to grunt feeding .eslintignore and .stylelintignore to
make js & css linters to ignore those 3rd part libe.

But those changes, make the grunt check to fail as far as they lead
to change in core detected when the check is being performed for a
non-core plugin. So we just proceed to ignore changes in those files
when it's the case.