### PR TITLE
Relax searches of issue code elsewhere in the message

### DIFF
--- a/tests/1-verify_commit_messages.bats
+++ b/tests/1-verify_commit_messages.bats
@@ -63,6 +63,12 @@ commit_apply_fixture_and_run() {
     assert_output "${shorthash}*error*The commit message does not begin with the expected issue code MDL-[0-9]{3,6} and a space."
 }
 
+@test "verify_commit_messages/verify_commit_messages.sh: warning elsewhere" {
+    commit_apply_fixture_and_run warning-elsewhere.patch
+    assert_failure
+    assert_output "${shorthash}*warning*The commit message contains the expected issue code MDL-12345 but in wrong place. That is allowed only for epics or issues with subtasks. Verify it."
+}
+
 @test "verify_commit_messages/verify_commit_messages.sh: no colon" {
     commit_apply_fixture_and_run no-colon.patch
     assert_failure

--- a/tests/fixtures/verify_commit_messages/warning-elsewhere.patch
+++ b/tests/fixtures/verify_commit_messages/warning-elsewhere.patch
@@ -1,0 +1,26 @@
+From 6e0eeb392b286f2837ce28b2d40d6bc967371648 Mon Sep 17 00:00:00 2001
+From: Dan Poltawski <dan@moodle.com>
+Date: Fri, 29 Jul 2016 12:54:22 +0100
+Subject: [PATCH 1/1] MDL-99999 area: short summary
+
+And issue being part of an epic or subtask of another can have the issue
+code specified elsewhere, for example: Part of MDL-12345
+
+And that will lead to a more relaxed warning instead of error.
+---
+ README.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/README.txt b/README.txt
+index 729dbe4..af81703 100644
+--- a/README.txt
++++ b/README.txt
+@@ -26,3 +26,5 @@ Moodle is written in PHP and JavaScript and uses an SQL database for storing
+ the data.
+ 
+ See <https://docs.moodle.org> for details of Moodle's many features.
++
++a dummy commit!
+-- 
+2.9.0
+

--- a/verify_commit_messages/verify_commit_messages.sh
+++ b/verify_commit_messages/verify_commit_messages.sh
@@ -149,11 +149,11 @@ for c in ${commits}; do
                 # verify subject begins with matching issue code + space. Error.
                 if [[ ${hasissuecode} ]]; then
                     if [[ ! "${line}" =~ ^${issuecode}\  ]]; then
-                        # If the issue code in anywhere else in the message relax it a bit. Warning. Else Error.
-                        if [[ "${message}" =~ ${issuecode}\  ]]; then
-                            echo "${c}*warning*The commit message contains the expected issue code ${issuecode} but in wrong place. That is allowed only for epics or issues with subtasks. Verify it."
-                        elif [[ "${line}" =~ ^${issuecode}:\  ]]; then
+                        if [[ "${line}" =~ ^${issuecode}:\  ]]; then
                             echo "${c}*warning*The commit message contains ${issuecode} followed by a colon. The expected format is '${issuecode} codearea: message'"
+                        # If the issue code in anywhere else in the message relax it a bit. Warning. Else Error.
+                        elif [[ "${message}" =~ ${issuecode} ]]; then
+                            echo "${c}*warning*The commit message contains the expected issue code ${issuecode} but in wrong place. That is allowed only for epics or issues with subtasks. Verify it."
                         else
                             echo "${c}*error*The commit message does not contain the expected issue code ${issuecode} and a space."
                         fi


### PR DESCRIPTION
We don't need the issue code to be followed by space
when searching for it in the message. Only when searching
in the 1st line.

Covered with tests.

Once merged to laptop and master branches... it would be great to force a "cime" on https://tracker.moodle.org/browse/MDL-62610 where the problem was detected with "Part of MDL-62610" being the end of the message (without the trailing space).

Ciao :-)