### PR TITLE
Improve detection of merge commits

### DIFF
--- a/tests/1-verify_commit_messages.bats
+++ b/tests/1-verify_commit_messages.bats
@@ -42,6 +42,12 @@ commit_apply_fixture_and_run() {
     assert_output ""
 }
 
+@test "verify_commit_messages/verify_commit_messages.sh: message contains the word parent" {
+    commit_apply_fixture_and_run includes-parent-in-message.patch
+    assert_success
+    assert_output ""
+}
+
 @test "verify_commit_messages/verify_commit_messages.sh: long first line " {
     commit_apply_fixture_and_run too-long.patch
     assert_failure

--- a/tests/fixtures/verify_commit_messages/includes-parent-in-message.patch
+++ b/tests/fixtures/verify_commit_messages/includes-parent-in-message.patch
@@ -1,0 +1,25 @@
+From 6e0eeb392b286f2837ce28b2d40d6bc967371648 Mon Sep 17 00:00:00 2001
+From: Dan Poltawski <dan@moodle.com>
+Date: Fri, 29 Jul 2016 12:54:22 +0100
+Subject: [PATCH 1/1] MDL-12345 area: short summary
+
+This commit message should not fail just because it has the word
+parent as the first word in the line.
+
+---
+ README.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/README.txt b/README.txt
+index 729dbe4..af81703 100644
+--- a/README.txt
++++ b/README.txt
+@@ -26,3 +26,5 @@ Moodle is written in PHP and JavaScript and uses an SQL database for storing
+ the data.
+ 
+ See <https://docs.moodle.org> for details of Moodle's many features.
++
++a dummy commit!
+-- 
+2.9.0
+

--- a/verify_commit_messages/verify_commit_messages.sh
+++ b/verify_commit_messages/verify_commit_messages.sh
@@ -84,7 +84,7 @@ for c in ${commits}; do
     numproblems=0
     message=$(${gitcmd} show -s --pretty=format:%B ${c})
     # detect if the commit is a merge
-    numparents=$(${gitcmd} cat-file -p ${c} | grep '^parent ' | wc -l)
+    numparents=$(${gitcmd} show --no-patch --format="%P" ${c} | wc -w)
     if [[ ${numparents} -gt 1 ]]; then
         ismerge=1
         mergecommits=$((mergecommits+1))


### PR DESCRIPTION
Consider the following commit message:
```
2018 sm:MDL-63619-master> git cat-file -p 9b0f1f44649
--
tree 6b82a88a4971ae18b9144d489379724e52de6188
parent 3cced42eb37a1e92a2ff38feb1c099ec54cc4e20
author Andrew Nicols <andrew@nicols.co.uk> 1539571531 +0800
committer Andrew Nicols <andrew@nicols.co.uk> 1539571531 +0800
 
MDL-63619 tool_dataprivacy: Fix inheritance from parent contexts
 
Inheritance should behave such that all contexts inherit from their
parent context.
 
Prior to this fix, if the value was not set on a context, then it was
getting a default of 'Inherit', but instead of inheritting from the
parent context, it was inheritting from its parent context _level_ which
is just wrong.
```


Currently we check the merge commit status using the following:
```
numparents=$(${gitcmd} cat-file -p ${c} \| grep '^parent ' \| wc -l)
```

This matches the above commit message in two places:
```
parent 3cced42eb37a1e92a2ff38feb1c099ec54cc4e20
parent context, it was inheritting from its parent context _level_ which
```

As a result, the commit is erroneously identified as a merge commit.

We can switch to a different method for determining the number of parents.