### PR TITLE
Conditional sorting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ addons:
   apt:
     packages:
       - bc
-      - oracle-java8-installer
-      - oracle-java8-set-default
+      - openjdk-8-jre-headless
 
 cache:
   directories:

--- a/remote_branch_checker/lib.php
+++ b/remote_branch_checker/lib.php
@@ -233,7 +233,8 @@ class remote_branch_reporter {
             'codedir' => dirname($this->directory) . '/',
             'errorweight' => 5,
             'warningweight' => 1,
-            'allowfiltering' => 0);
+            'allowfiltering' => 0,
+            'sorting' => 1);
         if ($node = $this->apply_xslt($params, $this->directory . '/grunt.xml', 'checkstyle2smurf.xsl')) {
             if ($check = $node->getElementsByTagName('check')->item(0)) {
                 $snode = $doc->importNode($check, true);

--- a/remote_branch_checker/xslt/checkstyle2smurf.xsl
+++ b/remote_branch_checker/xslt/checkstyle2smurf.xsl
@@ -5,6 +5,7 @@
   <!-- convert xml output generated in checkstyle xml into smurf xml format -->
   <xsl:output method="xml" indent="yes"/>
 
+  <xsl:param name="abbr">abbr</xsl:param>
   <xsl:param name="title">checkstyle</xsl:param>
   <xsl:param name="url">http://pear.php.net/package/PHP_CodeSniffer</xsl:param>
   <xsl:param name="description">checkstyle description</xsl:param>
@@ -12,6 +13,7 @@
   <xsl:param name="errorweight">3</xsl:param>
   <xsl:param name="warningweight">1</xsl:param>
   <xsl:param name="allowfiltering">1</xsl:param>
+  <xsl:param name="sorting">0</xsl:param>
 
   <xsl:template match="/">
     <check>
@@ -25,13 +27,19 @@
         <xsl:value-of select="$description"/>
       </description>
       <mess>
-          <xsl:apply-templates select="checkstyle/file/error">
-              <xsl:sort select="substring-after(../@name, $codedir)"/>
-              <xsl:sort select="@line" data-type="number"/>
-              <xsl:sort select="@source"/>
-              <xsl:sort select="@severity" order="descending"/>
-              <xsl:sort select="@message"/>
-          </xsl:apply-templates>
+          <xsl:choose>
+              <xsl:when test="$sorting='1'">
+                  <xsl:apply-templates select="checkstyle/file/error">
+                      <xsl:sort select="substring-after(../@name, $codedir)"/>
+                      <xsl:sort select="@line" data-type="number"/>
+                      <xsl:sort select="@source"/>
+                      <xsl:sort select="@severity"/>
+                  </xsl:apply-templates>
+              </xsl:when>
+              <xsl:otherwise>
+                  <xsl:apply-templates select="checkstyle/file/error"/>
+              </xsl:otherwise>
+              </xsl:choose>
       </mess>
     </check>
   </xsl:template>

--- a/tests/fixtures/remote_branch_checker/fixture-grunt-build-failed.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-grunt-build-failed.xml
@@ -60,13 +60,13 @@
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="1" numwarnings="1" allowfiltering="0">
     <description>This section shows files built by grunt and not commited</description>
     <mess>
-      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/18958c1906a1e71fa32a1dba7e3ec5f53b07abf0/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="warning" weight="1">
-        <message>Task "stylelint:scss" failed. Use --force to continue.</message>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/18958c1906a1e71fa32a1dba7e3ec5f53b07abf0/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
+        <message>Problems running grunt</message>
         <description/>
         <code/>
       </problem>
-      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/18958c1906a1e71fa32a1dba7e3ec5f53b07abf0/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
-        <message>Problems running grunt</message>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/18958c1906a1e71fa32a1dba7e3ec5f53b07abf0/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="warning" weight="1">
+        <message>Task "stylelint:scss" failed. Use --force to continue.</message>
         <description/>
         <code/>
       </problem>

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_manyproblems.xml
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_manyproblems.xml
@@ -131,13 +131,13 @@
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="1" numwarnings="1" allowfiltering="0">
     <description>This section shows files built by grunt and not commited</description>
     <mess>
-      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/b372aa8468452f5510ee41e0a3b44fb56ade77ac/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="warning" weight="1">
-        <message>Task "stylelint:css" failed. Use --force to continue.</message>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/b372aa8468452f5510ee41e0a3b44fb56ade77ac/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
+        <message>Problems running grunt</message>
         <description/>
         <code/>
       </problem>
-      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/b372aa8468452f5510ee41e0a3b44fb56ade77ac/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
-        <message>Problems running grunt</message>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/b372aa8468452f5510ee41e0a3b44fb56ade77ac/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="warning" weight="1">
+        <message>Task "stylelint:css" failed. Use --force to continue.</message>
         <description/>
         <code/>
       </problem>

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_oldbranch.xml
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_oldbranch.xml
@@ -96,13 +96,13 @@
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="1" numwarnings="1" allowfiltering="0">
     <description>This section shows files built by grunt and not commited</description>
     <mess>
-      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/8b0f63da1743bd175115ea9e07d298dd19500f9b/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="warning" weight="1">
-        <message>Task "jshint:files" failed. Use --force to continue.</message>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/8b0f63da1743bd175115ea9e07d298dd19500f9b/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
+        <message>Problems running grunt</message>
         <description/>
         <code/>
       </problem>
-      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/8b0f63da1743bd175115ea9e07d298dd19500f9b/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
-        <message>Problems running grunt</message>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/8b0f63da1743bd175115ea9e07d298dd19500f9b/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="warning" weight="1">
+        <message>Task "jshint:files" failed. Use --force to continue.</message>
         <description/>
         <code/>
       </problem>

--- a/tests/fixtures/remote_branch_checker/prechecker-fixture-stylelint.xml
+++ b/tests/fixtures/remote_branch_checker/prechecker-fixture-stylelint.xml
@@ -75,13 +75,13 @@
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="1" numwarnings="1" allowfiltering="0">
     <description>This section shows files built by grunt and not commited</description>
     <mess>
-      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/49effd12f320bb67f9b3b91c4a448b81745f13bf/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="warning" weight="1">
-        <message>Task "stylelint:scss" failed. Use --force to continue.</message>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/49effd12f320bb67f9b3b91c4a448b81745f13bf/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
+        <message>Problems running grunt</message>
         <description/>
         <code/>
       </problem>
-      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/49effd12f320bb67f9b3b91c4a448b81745f13bf/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="error" weight="5">
-        <message>Problems running grunt</message>
+      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/49effd12f320bb67f9b3b91c4a448b81745f13bf/#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Grunt" type="warning" weight="1">
+        <message>Task "stylelint:scss" failed. Use --force to continue.</message>
         <description/>
         <code/>
       </problem>


### PR DESCRIPTION
For some reason grunt executions not always lead to the same xml file, some elements become out of expected (fixture) order.

This add a mechanism to enforce a consistent ordering for those checks requiring them (right now, only the grunt ones).

With that, everything should be passing regularly.