### PR TITLE
 mustache_lint: Wrap stray tags into valid parent.

### DIFF
--- a/tests/1-mustache_lint.bats
+++ b/tests/1-mustache_lint.bats
@@ -76,7 +76,6 @@ setup () {
 
     # Assert result
     assert_failure
-    assert_output --partial "NPM installed validator found."
     assert_output --partial "Running mustache lint from $GIT_PREVIOUS_COMMIT to $GIT_COMMIT"
     assert_output --partial "lib/templates/linting.mustache - WARNING: HTML Validation error, line 2: End tag “p” seen, but there were open elements. (ello World</p></bo)"
     assert_output --partial "lib/templates/linting.mustache - WARNING: HTML Validation error, line 2: Unclosed element “span”. (<body><p><span>Hello )"
@@ -100,6 +99,24 @@ setup () {
     assert_output --partial "No mustache problems found"
 }
 
+@test "mustache_lint: Partial contains elements with strict parent requirement" {
+    # Set up.
+    git_apply_fixture 31-mustache_lint-partial.patch
+    export GIT_PREVIOUS_COMMIT=$FIXTURE_HASH_BEFORE
+    export GIT_COMMIT=$FIXTURE_HASH_AFTER
+
+    ci_run mustache_lint/mustache_lint.sh
+
+    # Assert result
+    assert_success
+    # We should not have a validation warning about stray tags.
+    refute_output --partial "lib/templates/linting.mustache - WARNING: HTML Validation error, line 2: Stray start tag “td”."
+    refute_output --partial "lib/templates/linting.mustache - WARNING: HTML Validation error, line 2: Stray end tag “td”."
+
+    assert_output --partial "lib/templates/linting.mustache - OK: Mustache rendered html succesfully"
+    assert_output --partial "No mustache problems found"
+}
+
 @test "mustache_lint: Full HTML page doesn't get embeded in <html> body" {
     # Set up.
     git_apply_fixture 31-mustache_lint-full-html-body.patch
@@ -110,7 +127,7 @@ setup () {
 
     # Assert result
     assert_success
-    # We should not have a vlidation warning about multiple 'html' tags.
+    # We should not have a validation warning about multiple 'html' tags.
     refute_output --partial 'Stray start tag “html”.'
 
     assert_output --partial "lib/templates/full-html-page.mustache - OK: Mustache rendered html succesfully"

--- a/tests/fixtures/31-mustache_lint-partial.patch
+++ b/tests/fixtures/31-mustache_lint-partial.patch
@@ -1,0 +1,53 @@
+From 21dcf559cc7850d03729f7679e2f1ce87db5cb4c Mon Sep 17 00:00:00 2001
+From: Ruslan Kabalin <ruslan.kabalin@gmail.com>
+Date: Fri, 18 Jan 2019 18:26:08 +0000
+Subject: [PATCH] MDL-56504 mustache: fixture for partial problem detection
+
+---
+ lib/templates/linting.mustache | 35 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+ create mode 100644 lib/templates/linting.mustache
+
+diff --git a/lib/templates/linting.mustache b/lib/templates/linting.mustache
+new file mode 100644
+index 00000000000..dffe9239d92
+--- /dev/null
++++ b/lib/templates/linting.mustache
+@@ -0,0 +1,35 @@
++{{!
++    This file is part of Moodle - http://moodle.org/
++
++    Moodle is free software: you can redistribute it and/or modify
++    it under the terms of the GNU General Public License as published by
++    the Free Software Foundation, either version 3 of the License, or
++    (at your option) any later version.
++
++    Moodle is distributed in the hope that it will be useful,
++    but WITHOUT ANY WARRANTY; without even the implied warranty of
++    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++    GNU General Public License for more details.
++
++    You should have received a copy of the GNU General Public License
++    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
++}}
++{{!
++    @template core/linting
++
++    A test for for mustache linting tests.
++
++    Classes required for JS:
++    * none
++
++    Data attributes required for JS:
++    * none
++
++    Context variables required for this template:
++    * none
++
++    Example context (json):
++    {
++    }
++}}
++<td>Hello World</td>
+--
+2.11.0


### PR DESCRIPTION
This fix is partially addressing [MDL-56504](https://tracker.moodle.org/browse/MDL-56504) by adding an extra wrappers to tags that have strict parent requirement according to the spec (e.g. it is invalid to use `<li>...</li>` without wrapping it `<ul>...</ul>` tag).

Bats run output:
If only test (ac593e9) is applied:
```
ci:mustache-lint-partials-stray-tags-fix> bats tests/1-mustache_lint.bats 
 ✓ mustache_lint: Good mustache file
 ✓ mustache_lint: No example content
 ✓ mustache_lint: Example content invalid json
 ✓ mustache_lint: Mustache syntax error
 ✓ mustache_lint: HTML validation issue
 ✓ mustache_lint: Partials are loaded
 ✗ mustache_lint: Partial contains elements with strict parent requirement
   (from function `assert_success' in file tests/libs/bats-assert/src/assert.bash, line 114,
    in test file tests/1-mustache_lint.bats, line 111)
     `assert_success' failed
   
   -- command failed --
   status : 1
   output (5 lines):
     Validating using https://html5.validator.nu
     Running mustache lint from f851201f58662264ad7864dbbf8e2240ce7bf84a to de7907ebe5594bac7cea77c2bf847ea7c4554999:
     /home/ruslan/git/ci/moodle/lib/templates/linting.mustache - WARNING: HTML Validation error, line 2: Stray start tag “td”. (ad><body><td>Hello )
     /home/ruslan/git/ci/moodle/lib/templates/linting.mustache - WARNING: HTML Validation error, line 2: Stray end tag “td”. (ello World</td></bo)
     Mustache lint problems found
   --
   
 ✓ mustache_lint: Full HTML page doesn't get embeded in <html> body
 ✓ mustache_lint: Theme templates load theme partials
 ✓ mustache_lint: Test quote and uniq helpers are working
 ✓ mustache_lint: Test eslint doesn't run when not present
 ✓ mustache_lint: Test eslint runs when npm installed
```
when feature patch (8523227) is applied:
```
ci:mustache-lint-partials-stray-tags-fix> bats tests/1-mustache_lint.bats 
 ✓ mustache_lint: Good mustache file
 ✓ mustache_lint: No example content
 ✓ mustache_lint: Example content invalid json
 ✓ mustache_lint: Mustache syntax error
 ✓ mustache_lint: HTML validation issue
 ✓ mustache_lint: Partials are loaded
 ✓ mustache_lint: Partial contains elements with strict parent requirement
 ✓ mustache_lint: Full HTML page doesn't get embeded in <html> body
 ✓ mustache_lint: Theme templates load theme partials
 ✓ mustache_lint: Test quote and uniq helpers are working
 ✓ mustache_lint: Test eslint doesn't run when not present
 ✓ mustache_lint: Test eslint runs when npm installed

12 tests, 0 failures
```