### PR TITLE
MDLSITE-5716 Fix parsing component names in the commit AMOScript

### DIFF
--- a/tests/1-verify_commit_messages.bats
+++ b/tests/1-verify_commit_messages.bats
@@ -96,7 +96,8 @@ commit_apply_fixture_and_run() {
 @test "verify_commit_messages/verify_commit_messages.sh: AMOS bad syntax" {
     commit_apply_fixture_and_run amos-bad-syntax.patch
     assert_failure
-    assert_output "${shorthash}*error*AMOS - Instruction not understood 'MOV [nametextarea, mod_data][fieldtypelabel, datafield_textarea]'"
+    assert_output --partial "${shorthash}*error*AMOS - Instruction not understood 'MOV [nametextarea, mod_data][fieldtypelabel, datafield_textarea]'"
+    assert_output --partial "${shorthash}*error*AMOS - Instruction not understood 'CPY [foo,bar],[foo,mod__bar]'"
 }
 
 @test "verify_commit_messages/verify_commit_messages.sh: AMOS incomplete commands" {
@@ -108,7 +109,8 @@ commit_apply_fixture_and_run() {
 @test "verify_commit_messages/verify_commit_messages.sh: AMOS good commands" {
     commit_apply_fixture_and_run amos-good-commands.patch
     assert_success
-    assert_output "${shorthash}*info*AMOS - String to be copied: searchengine/admin to type_search/plugin"
+    assert_output --partial "${shorthash}*info*AMOS - String to be copied: searchengine/admin to type_search/plugin"
+    assert_output --partial "${shorthash}*info*AMOS - String to be copied: emailpasswordchangeinfosubject/moodle to emailpasswordchangeinfosubject/auth_oauth2"
 }
 
 @test "verify_commit_messages/verify_commit_messages.sh: AMOS no modified lang files" {

--- a/tests/fixtures/verify_commit_messages/amos-bad-syntax.patch
+++ b/tests/fixtures/verify_commit_messages/amos-bad-syntax.patch
@@ -6,10 +6,11 @@ Subject: [PATCH 1/1] MDL-12345 amos: dummy commit
 Here we are going to test the commit checker..
 
 This commit should fail because i'm introducing an amos syntax error
-with nametextarea
+with nametextarea and mod__bar
 
 AMOS BEGIN
  MOV [nametextarea, mod_data][fieldtypelabel, datafield_textarea]
+ CPY [foo,bar],[foo,mod__bar]
 AMOS END
 ---
  mod/data/lang/en/data.php | 1 -

--- a/tests/fixtures/verify_commit_messages/amos-good-commands.patch
+++ b/tests/fixtures/verify_commit_messages/amos-good-commands.patch
@@ -7,6 +7,7 @@ This should be correct AMOS syntax
 
 AMOS BEGIN
   CPY [searchengine,admin],[type_search,plugin]
+  CPY [emailpasswordchangeinfosubject,core],[emailpasswordchangeinfosubject,auth_oauth2]
 AMOS END
 ---
  lang/en/admin.php | 1 -

--- a/verify_commit_messages/amoslib.php
+++ b/verify_commit_messages/amoslib.php
@@ -321,20 +321,30 @@ class amos_script_parser {
      * @return string|false legacy style like moodle, admin, workshop or auth_ldap, false in case of error
      */
     protected static function legacy_component_name($newstyle) {
+
         $newstyle = trim($newstyle);
-        if (preg_match('/[^a-z_\.-]/', $newstyle)) {
-            // only letters and underscore should be allowed - blame component 'moodle.org' for the dot
+
+        // See {@link PARAM_COMPONENT}.
+        if (!preg_match('/^[a-z]+(_[a-z][a-z0-9_]*)?[a-z0-9]+$/', $newstyle)) {
             return false;
         }
+
+        if (strpos($newstyle, '__') !== false) {
+            return false;
+        }
+
         if ($newstyle == 'core') {
             return 'moodle';
         }
+
         if (substr($newstyle, 0, 5) == 'core_') {
             return substr($newstyle, 5);
         }
+
         if (substr($newstyle, 0, 4) == 'mod_') {
             return substr($newstyle, 4);
         }
+
         return $newstyle;
     }
 }


### PR DESCRIPTION
Components with a digit in the name (such as auth_oauth2) were not
correctly recognised before. This has been fixed upstream in AMOS and
the same fix is being copied over here.

Extending the tests to cover both newly covered cases - valid component
names with a digit, and invalid component name with double underscore.