### PR TITLE
 MDLSITE-5739 mustache_lint: error when running on openjdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+
 language: php
 
 sudo: false
@@ -6,7 +8,6 @@ addons:
   apt:
     packages:
       - bc
-      - openjdk-8-jre-headless
 
 cache:
   directories:
@@ -18,19 +19,10 @@ services:
 php:
     - 7.1
 
-matrix:
-  include:
-    - dist: xenial
-      env: TEST_SUITE="0-*" DIST="xenial"
-    - dist: xenial
-      env: TEST_SUITE="1-*" DIST="xenial"
-    - dist: xenial
-      env: TEST_SUITE="2-*" DIST="xenial"
-
 env:
-    - TEST_SUITE="0-*" DIST="trusty"
-    - TEST_SUITE="1-*" DIST="trusty"
-    - TEST_SUITE="2-*" DIST="trusty"
+    - TEST_SUITE="0-*"
+    - TEST_SUITE="1-*"
+    - TEST_SUITE="2-*"
 
 install:
   - git clone --depth 1 https://github.com/sstephenson/bats.git $HOME/bats

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,15 @@ cache:
 php:
     - 7.1
 
+matrix:
+  include:
+    - dist: xenial
+      env: TEST_SUITE="0-*"
+    - dist: xenial
+      env: TEST_SUITE="1-*"
+    - dist: xenial
+      env: TEST_SUITE="2-*"
+
 env:
     - TEST_SUITE="0-*"
     - TEST_SUITE="1-*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,22 +12,25 @@ cache:
   directories:
       - $HOME/cachedir
 
+services:
+  - mysql
+
 php:
     - 7.1
 
 matrix:
   include:
     - dist: xenial
-      env: TEST_SUITE="0-*"
+      env: TEST_SUITE="0-*" DIST="xenial"
     - dist: xenial
-      env: TEST_SUITE="1-*"
+      env: TEST_SUITE="1-*" DIST="xenial"
     - dist: xenial
-      env: TEST_SUITE="2-*"
+      env: TEST_SUITE="2-*" DIST="xenial"
 
 env:
-    - TEST_SUITE="0-*"
-    - TEST_SUITE="1-*"
-    - TEST_SUITE="2-*"
+    - TEST_SUITE="0-*" DIST="trusty"
+    - TEST_SUITE="1-*" DIST="trusty"
+    - TEST_SUITE="2-*" DIST="trusty"
 
 install:
   - git clone --depth 1 https://github.com/sstephenson/bats.git $HOME/bats

--- a/mustache_lint/mustache_lint.php
+++ b/mustache_lint/mustache_lint.php
@@ -198,7 +198,7 @@ function check_html_validation($content) {
     if (strpos($content, '<head>') === false) {
         // Primative detection if we have full html body, if not, wrap it.
         // (This isn't bulletproof, obviously).
-        $wrappedcontent = "<!DOCTYPE html><head><title>Validate</title></head><body>\n{$content}\n</body></html>";
+        $wrappedcontent = "<!DOCTYPE html><html lang=\"en\"><head><title>Validate</title></head><body>\n{$content}\n</body></html>";
     } else {
         $wrappedcontent = $content;
     }

--- a/mustache_lint/mustache_lint.sh
+++ b/mustache_lint/mustache_lint.sh
@@ -24,10 +24,12 @@ mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 validator=${validator:-"https://html5.validator.nu"}
 if [ -f "$mydir/../node_modules/vnu-jar/build/dist/vnu.jar" ]
 then
-    if java -version 2>&1 >/dev/null | grep -q "java version"
+    if java -version 2>&1 >/dev/null | grep -Eq "(java|openjdk) version"
     then
-        javaversion=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
-        if [[ "$javaversion" > "1.8" ]]
+        # Extract major and minor digits of version and compare it as float
+        # numbers. Not error proof, but sufficient to ensure it is >= 1.8
+        javaversion=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/^\([0-9]*\.[0-9]*\).*$/\1/')
+        if [ $( echo "${javaversion} >= 1.8" | bc ) == 1 ]
         then
             echo "NPM installed validator found."
             validator="$( cd $mydir/../node_modules/ && pwd)/vnu-jar/build/dist/vnu.jar"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "moodle-local_ci",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "vnu-jar": {
+      "version": "18.11.5",
+      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-18.11.5.tgz",
+      "integrity": "sha512-XxTYLOUgQYdvIlAgX1BtxZiQ97/OKuBaEojqZdjMnjI+OXDkSyQGNGpzUQIQygeRrFVdQ1/eAVfiRE/iIlV0fg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "description": "Tools for CI with Moodle",
   "private": true,
   "dependencies": {
-    "vnu-jar": "^17.3.0"
+    "vnu-jar": "18.11.5"
   }
 }

--- a/tests/fixtures/31-mustache_lint-full-html-body.patch
+++ b/tests/fixtures/31-mustache_lint-full-html-body.patch
@@ -25,7 +25,7 @@ index 0000000..386ffb0
 +    }
 +}}
 +<!DOCTYPE html>
-+<html>
++<html lang="en">
 +<head>
 +<title>Test page</title>
 +</head>


### PR DESCRIPTION
More details:
* https://tracker.moodle.org/browse/MDLSITE-5739
* https://github.com/blackboard-open-source/moodle-plugin-ci/issues/91

As I can see, repo does not include `package-lock.json`, I guess this is intentional, as previously requirement was "^17.3.0" (any compatible version)? I do not use "^18.11.5" as it seems bring up unstable releases above that version when npm is initialised or updated. Perhaps we need to introduce `package-lock.json` to make sure that end user is using the same version which has been integration-tested here?