### PR TITLE
Launch predefined jobs against issues returned by a query

### DIFF
--- a/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Look all reopened issues under current integration and move them out
+#jiraclicmd: full execution path of the jira cli
+#jiraserver: jira server url we are going to connect to
+#jirauser: user that will perform the execution
+#jirapass: password of the user
+#jenkinsserver: Full URL of the jenkins server where the jobs will be launched.
+#jenkinsauth: String that defines the method to connect to the jenkins server, can be -ssh
+#  (requiring keys to be in place and jenkins ssh enabled), or also -html (and then
+#  use a combination of user and password or token). See Jenkins CLI docs for more info.
+#cf_repository: id for "Pull from Repository" custom field (customfield_10100)
+#cf_branches: pairs of moodle branch and id for "Pull XXXX Branch" custom field (master:customfield_10111,....)
+#criteria: "awaiting integration"...
+#schedulemins: Frecuency (in minutes) of the schedule (cron) of this job. IMPORTANT to ensure that they match or there will be issues processed more than once or skipped.
+#quiet: if enabled ("true"), don't perform any action in the Tracker.
+
+# Let's go strict (exit on error)
+set -e
+
+# Verify everything is set
+required="WORKSPACE jiraclicmd jiraserver jirauser jirapass jenkinsserver jenkinsauth cf_repository cf_branches criteria schedulemins quiet"
+for var in $required; do
+    if [ -z "${!var}" ]; then
+        echo "Error: ${var} environment variable is not defined. See the script comments."
+        exit 1
+    fi
+done
+
+# wipe the workspace
+rm -fr "${WORKSPACE}"/*
+
+# file where results will be sent
+resultfile=${WORKSPACE}/bulk_prelaunch_jobs
+echo -n > "${resultfile}"
+
+# Calculate some variables
+mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+basereq="${jiraclicmd} --server ${jiraserver} --user ${jirauser} --password ${jirapass}"
+
+# Normalise criteria
+criteria=${criteria// /_}
+
+# Validate criteria
+if [[ ! -f "${mydir}/criteria/${criteria}/query.sh" ]]; then
+    echo "Error: Incorrect criteria '${criteria}'"
+    exit 1
+fi
+
+echo "Using criteria: ${criteria}"
+
+# Apply some defaults
+maxcommitswarn=${maxcommitswarn:-10}
+maxcommitserror=${maxcommitserror:-100}
+
+# Execute the criteria query. It will save a list of issues (format 101) to $resultfile.
+. "${mydir}/criteria/${criteria}/query.sh"
+
+# Iterate over found issues and launch the prechecker for them
+while read issue; do
+    issueresult="success"
+    echo -n > "${resultfile}.${issue}.txt"
+    echo "Results for ${issue} (https://tracker.moodle.org/browse/${issue})"
+    # Fetch repository
+    ${basereq} --action getFieldValue \
+               --issue ${issue} \
+               --field ${cf_repository} \
+               --file "${resultfile}.repository" > /dev/null
+    repository=$(cat "${resultfile}.repository" | tr -d ' ')
+    rm "${resultfile}.repository"
+    if [[ -z "${repository}" ]]; then
+        issueresult="error"
+        echo "(x) Error: the repository field is empty. Nothing was launched." | tee -a "${resultfile}.${issue}.txt"
+    else
+        echo "Issue ${issue} has git repository ${repository}"
+    fi
+
+    # Iterate over the candidate branches
+    branchesfound=""
+    for candidate in ${cf_branches//,/ }; do
+        # Nothing to process with empty repository
+        if [[ -z "${repository}" ]]; then
+            break
+        fi
+        # Split into target branch and custom field
+        target=${candidate%%:*}
+        cf_branch=${candidate##*:}
+        # Fetch branch information
+        ${basereq} --action getFieldValue \
+                   --issue ${issue} \
+                   --field ${cf_branch} \
+                   --file "${resultfile}.branch" > /dev/null
+        branch=$(cat "${resultfile}.branch" | tr -d ' ')
+        rm "${resultfile}.branch"
+
+        # Branch found
+        if [[ -n "${branch}" ]]; then
+            branchesfound=1
+            echo "Launching automatic jobs for branch ${branch}" | tee -a "${resultfile}.${issue}.txt"
+            # Launch the jobs for current criteria (jobs.sh)
+            jenkinsreq="java -jar ${mydir}/../../jenkins_cli/jenkins-cli.jar -s ${jenkinsserver} ${jenkinsauth} build"
+            . "${mydir}/criteria/${criteria}/jobs.sh"
+            # Calculate the type, job names and build numbers
+            regex="^([^:]+): Started ([^#]+) #([0-9]+)$"
+            while read jobline; do
+                [[ ${jobline} =~ ${regex} ]]
+                if [[ -n ${BASH_REMATCH[0]} ]]; then
+                    echo "  ${BASH_REMATCH[0]}"
+                    type=${BASH_REMATCH[1]}
+                    job=${BASH_REMATCH[2]}
+                    build=${BASH_REMATCH[3]}
+                    joburl="${jenkinsserver}/view/Testing/job/${job}/${build}/"
+                    joburl=$(echo ${joburl} | sed 's/ /%20/g')
+                    echo "    - Type: ${type}"
+                    echo "    - Job: ${job}"
+                    echo "    - Build: ${build}"
+                    echo "    - URL: ${joburl}"
+                    echo "    - Result: ${type}: ${joburl}"
+                    echo "  - ${type}: ${joburl}" >> "${resultfile}.${issue}.txt"
+                fi
+            done < "${resultfile}.jenkinscli"
+            echo "" >> "${resultfile}.${issue}.txt"
+            rm "${resultfile}.jenkinscli"
+        fi
+    done
+
+    echo ""
+    # Verify we have processed some branch.
+    if [[ ! -z  "${repository}" ]] && [[ -z "${branchesfound}" ]]; then
+        echo "(x) Error: all the branch fields are incorrect. Nothing was checked." | tee -a "${resultfile}.${issue}.txt"
+    fi
+
+    # Execute the criteria postissue. It will perform the needed changes in the tracker for the current issue
+    if [[ ${quiet} == "false" ]]; then
+        echo "  - Sending results to the Tracker"
+        . "${mydir}/criteria/${criteria}/postissue.sh"
+    fi
+done < "${resultfile}"

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/jobs.sh
@@ -1,0 +1,30 @@
+# DISABLED FOR NOW, AS FAR AS WE AREN'T PLENTY OF FREE SLOTS
+# Better concentrate on Behat runs for now and save some workers.
+# We want to launch always an Oracle PHPUNIT
+#echo -n "PHPUnit (oracle): " >> "${resultfile}.jenkinscli"
+#${jenkinsreq} "DEV.02 - Developer-requested PHPUnit" \
+#    -p REPOSITORY=${repository} \
+#    -p BRANCH=${branch} \
+#    -p DATABASE=oci \
+#    -p PHPVERSION=7.2 \
+#    -w >> "${resultfile}.jenkinscli"
+
+# We want to launch always a Behat (goutte) job
+echo -n "Behat (goutte): " >> "${resultfile}.jenkinscli"
+${jenkinsreq} "DEV.01 - Developer-requested Behat" \
+    -p REPOSITORY=${repository} \
+    -p BRANCH=${branch} \
+    -p DATABASE=pgsql \
+    -p PHPVERSION=7.2 \
+    -p BROWSER=goutte \
+    -w >> "${resultfile}.jenkinscli"
+
+# We want to launch always a Behat (chrome) job
+echo -n "Behat (chrome): " >> "${resultfile}.jenkinscli"
+${jenkinsreq} "DEV.01 - Developer-requested Behat" \
+    -p REPOSITORY=${repository} \
+    -p BRANCH=${branch} \
+    -p DATABASE=pgsql \
+    -p PHPVERSION=7.2 \
+    -p BROWSER=chrome \
+    -w >> "${resultfile}.jenkinscli"

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/postissue.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/postissue.sh
@@ -1,0 +1,5 @@
+# Add the comment with results.
+${basereq} --action addComment \
+    --issue ${issue} \
+    --file "${resultfile}.${issue}.txt" \
+    --role "Integrators"

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/query.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/query.sh
@@ -1,0 +1,9 @@
+${basereq} --action getIssueList \
+           --search "project = 'Moodle' \
+                 AND status = 'Waiting for integration review' \
+                 AND status WAS NOT 'Waiting for integration review' BEFORE '-${schedulemins}' \
+                 AND participants not in (tobic) \
+                 AND level IS EMPTY \
+                 ORDER BY priority DESC, votes DESC, 'Last comment date' ASC" \
+           --outputFormat 101 \
+           --file "${resultfile}"


### PR DESCRIPTION
This job just allows you to perform JQL queries against
a Jira server, launching a number of defined Jenkins jobs for each
issue found and performins some post-actions for each issue.

We are going to use it with a criteria named "awaiting_integration"
so, every user that lands to integration gets some CI jobs executed
for every branch in the issue.

At Jenkins level we'll be throttling those (DEV) jobs to prevent
this script to end using all the available workers.

It's important to make the schedulemins parameter to match the
intervals (in minutes) in the job schedule plan (cron) or some
issues could be processed twice or skipped.

Finally note that the current criteria includes a extra condition:

AND participants not in (tobic)

So we'll be processing an issue only once. This can be tidied/chaged
later, but for now it's a basic protection trying to avoid an issue
going back and forth to consume too much infrastructure resources.

Also note that, for now, we have disabled the Oracle PHPUnit job, just
to sabe some workers until we have the job controlled and decide that
we can add more jobs to it.

This job will be launched by the "TR - Bulk pre-launch DEV jobs
(awaiting_integration)" job that has been already created and is
waiting for this to land to perform the final configuration and
schedule it.