### PR TITLE
Ignore ics files in illegal whitespace checks

### DIFF
--- a/define_excluded/define_excluded.sh
+++ b/define_excluded/define_excluded.sh
@@ -86,6 +86,7 @@ yui/build/
 *.csv
 *.gif
 *.jpg
+*.ics
 *.png
 *.svg"
 


### PR DESCRIPTION
ICS files must have a proper line break so will always fail the illegal whitespace check. Let's just ignore them. They're a false positive.