### PR TITLE
Bump to php72 (new 3.9 requirement) and move dependent tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
   - mysql
 
 php:
-    - 7.1
+    - 7.2
 
 env:
     - TEST_SUITE="0-*"

--- a/tests/1-compare_databases.bats
+++ b/tests/1-compare_databases.bats
@@ -37,18 +37,18 @@ setup () {
     assert_output --partial 'Error: dbtype environment variable is not defined. See the script comments.'
 }
 
-@test "compare_databases/compare_databases.sh: single actual (>= 31_STABLE) branch runs work" {
+@test "compare_databases/compare_databases.sh: single actual (>= 35_STABLE) branch runs work" {
     export gitbranchinstalled=master
-    export gitbranchupgraded=MOODLE_32_STABLE
+    export gitbranchupgraded=MOODLE_35_STABLE
 
     ci_run compare_databases/compare_databases.sh
     assert_success
-    assert_output --partial 'Info: Origin branches: (1) MOODLE_32_STABLE'
+    assert_output --partial 'Info: Origin branches: (1) MOODLE_35_STABLE'
     assert_output --partial 'Info: Target branch: master'
     assert_output --partial 'Info: Installing Moodle master into ci_installed_'
-    assert_output --partial 'Info: Comparing master and upgraded MOODLE_32_STABLE'
-    assert_output --partial 'Info: Installing Moodle MOODLE_32_STABLE into ci_upgraded_'
-    assert_output --partial 'Info: Upgrading Moodle MOODLE_32_STABLE to master into ci_upgraded_'
+    assert_output --partial 'Info: Comparing master and upgraded MOODLE_35_STABLE'
+    assert_output --partial 'Info: Installing Moodle MOODLE_35_STABLE into ci_upgraded_'
+    assert_output --partial 'Info: Upgrading Moodle MOODLE_35_STABLE to master into ci_upgraded_'
     assert_output --partial 'Info: Comparing databases ci_installed_'
     assert_output --partial 'Info: OK. No problems comparing databases ci_installed_'
     assert_output --partial 'Ok: Process ended without errors'
@@ -57,36 +57,36 @@ setup () {
     assert_success
 }
 
-@test "compare_databases/compare_databases.sh: single old (< 31_STABLE) branch runs work" {
-    export gitbranchinstalled=v3.0.5
-    export gitbranchupgraded=v3.0.1
+@test "compare_databases/compare_databases.sh: single old (< 35_STABLE) branch runs work" {
+    export gitbranchinstalled=v3.4.5
+    export gitbranchupgraded=v3.4.1
 
     ci_run compare_databases/compare_databases.sh
     assert_success
-    assert_output --partial 'Info: Origin branches: (1) v3.0.1'
-    assert_output --partial 'Info: Target branch: v3.0.5'
-    assert_output --partial 'Info: Installing Moodle v3.0.5 into ci_installed_'
-    assert_output --partial 'Info: Comparing v3.0.5 and upgraded v3.0.1'
-    assert_output --partial 'Info: Installing Moodle v3.0.1 into ci_upgraded_'
-    assert_output --partial 'Info: Upgrading Moodle v3.0.1 to v3.0.5 into ci_upgraded_'
+    assert_output --partial 'Info: Origin branches: (1) v3.4.1'
+    assert_output --partial 'Info: Target branch: v3.4.5'
+    assert_output --partial 'Info: Installing Moodle v3.4.5 into ci_installed_'
+    assert_output --partial 'Info: Comparing v3.4.5 and upgraded v3.4.1'
+    assert_output --partial 'Info: Installing Moodle v3.4.1 into ci_upgraded_'
+    assert_output --partial 'Info: Upgrading Moodle v3.4.1 to v3.4.5 into ci_upgraded_'
     assert_output --partial 'Info: Comparing databases ci_installed_'
     assert_output --partial 'Info: OK. No problems comparing databases ci_installed_'
     assert_output --partial 'Ok: Process ended without errors'
     refute_output --partial 'Error: Process ended with'
-    run [ -f $WORKSPACE/compare_databases_v3.0.5_logfile.txt ]
+    run [ -f $WORKSPACE/compare_databases_v3.4.5_logfile.txt ]
     assert_success
 }
 
 @test "compare_databases/compare_databases.sh: multiple branch runs work" {
     export gitbranchinstalled=master
-    export gitbranchupgraded=MOODLE_32_STABLE,MOODLE_33_STABLE
+    export gitbranchupgraded=MOODLE_36_STABLE,MOODLE_37_STABLE
 
     ci_run compare_databases/compare_databases.sh
     assert_success
-    assert_output --partial 'Info: Origin branches: (2) MOODLE_32_STABLE,MOODLE_33_STABLE'
+    assert_output --partial 'Info: Origin branches: (2) MOODLE_36_STABLE,MOODLE_37_STABLE'
     assert_output --partial 'Info: Target branch: master'
-    assert_output --partial 'Info: Comparing master and upgraded MOODLE_32_STABLE'
-    assert_output --partial 'Info: Comparing master and upgraded MOODLE_33_STABLE'
+    assert_output --partial 'Info: Comparing master and upgraded MOODLE_36_STABLE'
+    assert_output --partial 'Info: Comparing master and upgraded MOODLE_37_STABLE'
     assert_output --partial 'Ok: Process ended without errors'
     refute_output --partial 'Error: Process ended with'
     run [ -f $WORKSPACE/compare_databases_master_logfile.txt ]


### PR DESCRIPTION
Not much to say, just move to php72 (required for 3.9dev) and fix associated tests to the new requirements (Moodle >= 3.5...).

Currently broken... this should make travis & bats happy again.

Ciao :-)