### PR TITLE
Automatically follow .nvmrc when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - TEST_SUITE="0-*"
     - TEST_SUITE="1-*"
     - TEST_SUITE="2-*"
+    - TEST_SUITE="3-*"
 
 install:
   - git clone --depth 1 https://github.com/sstephenson/bats.git $HOME/bats

--- a/prepare_npm_stuff/prepare_npm_stuff.sh
+++ b/prepare_npm_stuff/prepare_npm_stuff.sh
@@ -3,6 +3,7 @@
 # $gitbranch: Branch we are going to install the DB
 # $nodecmd: Optional, path to the node executable (global)
 # $npmcmd: Optional, path to the npm executable (global)
+# $gitcmd: Optional, path to the git executable
 # $shifterversion: Optional, defaults to 0.4.6. Not installed if there is a package.json file (present in 29 and up)
 # $recessversion: Optional, defaults to 1.1.9 (Important! it's the only legacy version working. Older ones
 #    lead to empty results). Not installed if there is a package.json file (present in 29 and up)
@@ -26,17 +27,52 @@ shifterversion=${shifterversion:-0.4.6}
 recessversion=${recessversion:-1.1.9}
 nodecmd=${nodecmd:-node}
 npmcmd=${npmcmd:-npm}
+gitcmd=${gitcmd:-git}
+
+# Check if we have nvm installed @ home.
+export NVM_DIR="$HOME/.nvm"
+if [[ ! -r "${NVM_DIR}/nvm.sh" ]];then
+    # nvm not installed, let's install it with git
+    echo "INFO: nvm not found, installing via git"
+    $gitcmd clone --quiet https://github.com/nvm-sh/nvm.git "${NVM_DIR}"
+fi
+
+# Try to update to latest release (if git based installation only).
+if [[ -d "${NVM_DIR}/.git" ]]; then
+    # nvm installed via git, fetch updates
+    cd "${NVM_DIR}"
+    echo "INFO: nvm git installation found, updating to latest release"
+    $gitcmd fetch --quiet --tags origin
+    # Get latest nvm release and use it
+    export NVM_VERSION=$($gitcmd describe --abbrev=0 --tags --match "v[0-9]*" $($gitcmd rev-list --tags --max-count=1))
+    echo "INFO: using nvm version: ${NVM_VERSION}"
+    $gitcmd checkout --quiet ${NVM_VERSION}
+else
+    echo "INFO: nvm installation is not git-based, updating skipped"
+fi
+
+# Move to base directory
+cd ${gitdir}
+
+if [[ -r ".nvmrc" ]]; then
+    # Only if there is a .nvmrc file available
+    echo "INFO: .nvmrc file found: $(<.nvmrc). Installing node..."
+    # Source it, install and use the .nvmrc version
+    source $NVM_DIR/nvm.sh --no-use
+    echo "INFO: nvm version: $(nvm --version)"
+    nvm install > /dev/null 2>&1 && nvm use > /dev/null 2>&1
+    echo "INFO: node installation completed"
+else
+    echo "INFO: .nvmrc not found, nvm install skipped"
+fi
 
 # Print nodejs and npm versions for informative purposes
 if hash ${nodecmd} 2>/dev/null; then
     echo "INFO: node version: $(${nodecmd} --version)"
 fi
 if hash ${npmcmd} 2>/dev/null; then
-    echo "INFO: npm  version: $(${npmcmd} --version)"
+    echo "INFO: npm version: $(${npmcmd} --version)"
 fi
-
-# Move to base directory
-cd ${gitdir}
 
 # Unconditionally remove any previous installed stuff.
 # We always install from scratch. In caches we trust.

--- a/prepare_npm_stuff/prepare_npm_stuff.sh
+++ b/prepare_npm_stuff/prepare_npm_stuff.sh
@@ -60,7 +60,7 @@ if [[ -r ".nvmrc" ]]; then
     # Source it, install and use the .nvmrc version
     source $NVM_DIR/nvm.sh --no-use
     echo "INFO: nvm version: $(nvm --version)"
-    nvm install > /dev/null 2>&1 && nvm use > /dev/null 2>&1
+    nvm install && nvm use
     echo "INFO: node installation completed"
 else
     echo "INFO: .nvmrc not found, nvm install skipped"

--- a/tests/3-prepare_npm_stuff.bats
+++ b/tests/3-prepare_npm_stuff.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+load libs/shared_setup
+
+setup () {
+    create_git_branch master origin/master
+    rm -fr $gitdir/node_modules
+    rm -fr $gitdir/npm-shrinkwrap.json
+}
+
+@test "prepare_npm_stuff: Verify that .nvm existence is checked" {
+
+    ci_run prepare_npm_stuff/prepare_npm_stuff.sh
+
+    # Assert result.
+    assert_success
+    assert_output --partial "INFO: .nvmrc file found: $(<$gitdir/.nvmrc). Installing node..."
+    assert_output --partial "INFO: nvm version:"
+    assert_output --partial "INFO: node installation completed"
+    assert_output --partial "INFO: node version:"
+    assert_output --partial "INFO: npm version:"
+    assert_output --partial "INFO: Installing npm stuff following package/shrinkwrap details"
+    assert_output --partial "INFO:    - Installed grunt"
+}
+
+@test "prepare_npm_stuff: No HOME/.nvm installs via git" {
+    # Set up.
+    rm -fr $HOME/.nvm
+
+    ci_run prepare_npm_stuff/prepare_npm_stuff.sh
+
+    # Assert result.
+    assert_success
+    assert_output --partial "INFO: nvm not found, installing via git"
+    assert_output --partial "INFO: nvm git installation found, updating to latest release"
+    assert_output --partial "INFO: using nvm version:"
+    assert_output --partial "INFO: .nvmrc file found: $(<$gitdir/.nvmrc). Installing node..."
+    assert_output --partial "INFO: Installing npm stuff following package/shrinkwrap details"
+    assert_output --partial "INFO:    - Installed grunt"
+}
+
+@test "prepare_npm_stuff: No .nvmrc so we won't run any nvm command" {
+    # Set up.
+    rm -fr $gitdir/.nvmrc
+
+    ci_run prepare_npm_stuff/prepare_npm_stuff.sh
+
+    # Assert result.
+    # Cannot know if install will success or no (depends if npm/node binaries are elsewhere)
+    # (hence, we are not asserting the result, just that the case is handled)
+    assert_output --partial "INFO: using nvm version:"
+    assert_output --partial "INFO: .nvmrc not found, nvm install skipped"
+    assert_output --partial "INFO: Installing npm stuff following package/shrinkwrap details"
+}
+
+@test "prepare_npm_stuff: No HOME/.nvm neither .nvmrc is allowed" {
+    # Set up.
+    rm -fr $HOME/.nvm
+    rm -fr $gitdir/.nvmrc
+
+    ci_run prepare_npm_stuff/prepare_npm_stuff.sh
+
+    # Assert result.
+    # Cannot know if install will success or no (depends if npm/node binaries are elsewhere)
+    # (hence, we are not asserting the result, just that the case is handled)
+    assert_output --partial "INFO: nvm not found, installing via git"
+    assert_output --partial "INFO: nvm git installation found, updating to latest release"
+    assert_output --partial "INFO: using nvm version:"
+    assert_output --partial "INFO: .nvmrc not found, nvm install skipped"
+    assert_output --partial "INFO: Installing npm stuff following package/shrinkwrap details"
+}
+
+@test "prepare_npm_stuff: Install custom node v10.18.1 works ok" {
+    # Set up.
+    echo "v10.18.1" > $gitdir/.nvmrc
+
+    ci_run prepare_npm_stuff/prepare_npm_stuff.sh
+
+    # Assert result.
+    assert_success
+    assert_output --partial "INFO: using nvm version:"
+    assert_output --partial "INFO: .nvmrc file found: v10.18.1. Installing node.."
+    assert_output --partial "INFO: node installation completed"
+    assert_output --partial "INFO: node version: v10.18.1"
+    assert_output --partial "INFO: npm version: 6.13.4"
+    assert_output --partial "INFO: Installing npm stuff following package/shrinkwrap details"
+    assert_output --partial "INFO:    - Installed grunt"
+}


### PR DESCRIPTION
This enables all jobs using the script (security rebase, prechecker,
grunt, ... to, automatically use the current node version speficied
in the .nvmrc file.

This includes:
- installing nvm if not available ($HOME/.nvm)
- update nvm to the latest release
- source nvm
- install and use the .nvmrc version

Note that, once working, this renders the use of the nvm-wrapper
jenkins extension futile, as far as it does everything the extension
was doing previously. But better, because now we can control when
our moodle directoy is ready and with the correct .nvmrc file.

This will help to issues like MDL-66109, so whenever a node bump
happens, it's automatically detected and handled by our scripts
that will bump and use the new node version transparently.