### PR TITLE
Always source the execution of prepare_npm_stuff

### DIFF
--- a/grunt_process/grunt_process.sh
+++ b/grunt_process/grunt_process.sh
@@ -35,7 +35,7 @@ rm -fr ${outputfile}.stderr
 # Prepare all the npm stuff if needed
 # (only if the job is in charge of handling it, aka, $npminstall was passed
 if [[ -n ${npminstall} ]]; then
-    ${mydir}/../prepare_npm_stuff/prepare_npm_stuff.sh
+    . ${mydir}/../prepare_npm_stuff/prepare_npm_stuff.sh
 fi
 
 # Ensure we have grunt cli available before continue.

--- a/less_checker/less_checker.sh
+++ b/less_checker/less_checker.sh
@@ -33,7 +33,7 @@ rm -fr config.php
 rm -fr ${outputfile}
 
 # Prepare all the npm stuff if needed unconditionally
-${mydir}/../prepare_npm_stuff/prepare_npm_stuff.sh
+. ${mydir}/../prepare_npm_stuff/prepare_npm_stuff.sh
 
 # Iterate over all themes
 exitstatus=0

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -289,7 +289,7 @@ echo "Info: Calculating excluded files"
 
 echo "Info: Preparing npm"
 # Everything is ready, let's install all the required node stuff that some tools will use.
-${mydir}/../prepare_npm_stuff/prepare_npm_stuff.sh >> "${WORKSPACE}/work/prepare_npm.txt" 2>&1
+. ${mydir}/../prepare_npm_stuff/prepare_npm_stuff.sh >> "${WORKSPACE}/work/prepare_npm.txt" 2>&1
 
 # Before deleting all the files not part of the patchest we calculate the
 # complete list of valid components (plugins, subplugins and subsystems)

--- a/shifter_walk/shifter_walk.sh
+++ b/shifter_walk/shifter_walk.sh
@@ -33,7 +33,7 @@ rm -fr config.php
 rm -fr ${outputfile}
 
 # Prepare all the npm stuff if needed unconditionally
-${mydir}/../prepare_npm_stuff/prepare_npm_stuff.sh
+. ${mydir}/../prepare_npm_stuff/prepare_npm_stuff.sh
 
 shiftercmd="$(${npmcmd} bin)"/shifter
 if [ ! -x $shiftercmd ]; then


### PR DESCRIPTION
We need the selected npm and node binaries
available to caller.

This is a followup of #210 