### PR TITLE
Support multiple dev branches and 3-digit branches

### DIFF
--- a/tracker_automations/check_marked_as_integrated/util.sh
+++ b/tracker_automations/check_marked_as_integrated/util.sh
@@ -6,7 +6,10 @@ set -e
 # (since last roll happened, aka, since upstream last commit)
 function check_issue () {
     # Fetch the equivalent moodle.git branch (from where we are looking for existing commits).
-    ${1} fetch -q git://git.moodle.org/moodle.git ${3#"origin/"}
+    if ! $(${1} fetch -q git://git.moodle.org/moodle.git ${3#"origin/"}); then
+        echo "  WARNING: moodle.git ${3#"origin/"} fetching problems, cannot look for commits. Please check if that's correct."
+        return 0
+    fi
     if [[ -z $( ${1} log  --grep "${2}" --pretty=oneline --abbrev-commit FETCH_HEAD...${3} ) ]]; then
         # If the 2 branch heads (moodle.git and integration.git are exactly the same... it means that
         # we have just rolled. In those cases, we give the integrator up to 60 minutes to proceed to


### PR DESCRIPTION
This is the 1st set of changes providing:

- Support for multiple dev branches (passed as param).
- Support for 3-digit branch names (310, 400...)
- Enforce the fix-for versions rule: "Or stable versions or one dev
version"

TODO:
- Ensure that there aren't missing commits in dev branches, unless the
  "yes-only-master" label is present.
- Ensure that the most-immediate version is used when an issue goes
  to multiple dev branches.