### PR TITLE
Add possibility to exclude selected Mustache files from HTML validation

### DIFF
--- a/mustache_lint/mustache_lint.php
+++ b/mustache_lint/mustache_lint.php
@@ -73,6 +73,11 @@ if (strpos($FILENAME, $CFG->dirroot) !== 0) {
     exit(1);
 }
 
+// Ignore the .mustachelintignore file itself.
+if (basename($FILENAME) === '.mustachelintignore') {
+    exit(0);
+}
+
 require_once(__DIR__.'/simple_core_component_mustache_loader.php');
 require_once(__DIR__.'/js_helper.php');
 
@@ -105,10 +110,24 @@ try {
     exit(1);
 }
 
+$performhtmlvalidation = true;
+$ignorefilepath = dirname($FILENAME) . '/.mustachelintignore';
+if (file_exists($ignorefilepath)) {
+    foreach (file($ignorefilepath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $ignorepattern) {
+        if (strpos($ignorepattern, '#')) {
+            continue;
+        }
+        if (fnmatch(trim($ignorepattern), basename($FILENAME))) {
+            print_message('INFO', 'HTML validation skipped');
+            $performhtmlvalidation = false;
+        }
+    }
+}
+
 if (empty($content)) {
     // This probably is related to a partial or so on. Best to avoid raising an error.
     print_message('INFO', 'Template produced no content');
-} else {
+} else if ($performhtmlvalidation) {
     check_html_validation($content);
 }
 

--- a/tests/1-mustache_lint_plugins.bats
+++ b/tests/1-mustache_lint_plugins.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load libs/shared_setup
+
+setup () {
+    create_git_branch MOODLE_39_STABLE v3.9.1
+}
+
+@test "mustache_lint: Mustache files with Ionic3 syntax cause linting failure" {
+    # Set up.
+    git_apply_fixture 39-mustache_lint_plugins-templates.patch
+    export GIT_PREVIOUS_COMMIT=$FIXTURE_HASH_BEFORE
+    export GIT_COMMIT=$FIXTURE_HASH_AFTER
+
+    ci_run mustache_lint/mustache_lint.sh
+
+    # Assert result.
+    assert_failure
+    assert_output --partial "Running mustache lint from $GIT_PREVIOUS_COMMIT to $GIT_COMMIT"
+    assert_output --partial "local/test/templates/linting_ok.mustache - OK: Mustache rendered html succesfully"
+    assert_output --partial "local/test/templates/local/mobile/view.mustache - WARNING: HTML Validation info"
+    assert_output --partial "local/test/templates/mobile_view.mustache - WARNING: HTML Validation error"
+    assert_output --partial "Mustache lint problems found"
+}
+
+@test "mustache_lint: Mustache files can be excluded from linting" {
+    # Set up.
+    git_apply_fixture 39-mustache_lint_plugins-templates.patch
+    export GIT_PREVIOUS_COMMIT=$FIXTURE_HASH_BEFORE
+    git_apply_fixture 39-mustache_lint_plugins-ignores.patch
+    export GIT_COMMIT=$FIXTURE_HASH_AFTER
+
+    ci_run mustache_lint/mustache_lint.sh
+
+    # Assert result
+    assert_success
+    assert_output --partial "Running mustache lint from $GIT_PREVIOUS_COMMIT to $GIT_COMMIT"
+    assert_output --partial "local/test/templates/linting_ok.mustache - OK: Mustache rendered html succesfully"
+    assert_output --partial "local/test/templates/mobile_view.mustache - OK: Mustache rendered html succesfully"
+    assert_output --partial "local/test/templates/local/mobile/view.mustache - OK: Mustache rendered html succesfully"
+    assert_output --partial "local/test/templates/mobile_view.mustache - INFO: HTML validation skipped"
+    assert_output --partial "local/test/templates/local/mobile/view.mustache - INFO: HTML validation skipped"
+    assert_output --partial "No mustache problems found"
+}

--- a/tests/fixtures/39-mustache_lint_plugins-ignores.patch
+++ b/tests/fixtures/39-mustache_lint_plugins-ignores.patch
@@ -1,0 +1,33 @@
+From 02c7c121afe0cec8dacdb36ec5dd821ed92a15dc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?David=20Mudr=C3=A1k?= <david@moodle.com>
+Date: Mon, 7 Sep 2020 15:50:28 +0200
+Subject: [PATCH 2/2] Add .mustachelintignore to exclude files from HTML
+ validation
+
+---
+ local/test/templates/.mustachelintignore              | 2 ++
+ local/test/templates/local/mobile/.mustachelintignore | 3 +++
+ 2 files changed, 5 insertions(+)
+ create mode 100644 local/test/templates/.mustachelintignore
+ create mode 100644 local/test/templates/local/mobile/.mustachelintignore
+
+diff --git a/local/test/templates/.mustachelintignore b/local/test/templates/.mustachelintignore
+new file mode 100644
+index 0000000000..f2d6f7d6b4
+--- /dev/null
++++ b/local/test/templates/.mustachelintignore
+@@ -0,0 +1,2 @@
++# Ignore all the mobile app templates.
++mobile_*.mustache
+diff --git a/local/test/templates/local/mobile/.mustachelintignore b/local/test/templates/local/mobile/.mustachelintignore
+new file mode 100644
+index 0000000000..379d827608
+--- /dev/null
++++ b/local/test/templates/local/mobile/.mustachelintignore
+@@ -0,0 +1,3 @@
++# Ignore all the templates here.
++
++*.mustache
+-- 
+2.26.2
+

--- a/tests/fixtures/39-mustache_lint_plugins-templates.patch
+++ b/tests/fixtures/39-mustache_lint_plugins-templates.patch
@@ -1,0 +1,173 @@
+From e673b65dec0d2791aaaa522d6931a3030ce39344 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?David=20Mudr=C3=A1k?= <david@moodle.com>
+Date: Mon, 7 Sep 2020 15:26:42 +0200
+Subject: [PATCH 1/2] Add templates that we want to test
+
+The linting_ok.mustache should not raise any problem. But the other two
+use some Ionic3 / Angular specific syntax that would normally make their
+linting fail.
+---
+ local/test/templates/linting_ok.mustache      | 53 +++++++++++++++++++
+ .../test/templates/local/mobile/view.mustache | 41 ++++++++++++++
+ local/test/templates/mobile_view.mustache     | 41 ++++++++++++++
+ 3 files changed, 135 insertions(+)
+ create mode 100644 local/test/templates/linting_ok.mustache
+ create mode 100644 local/test/templates/local/mobile/view.mustache
+ create mode 100644 local/test/templates/mobile_view.mustache
+
+diff --git a/local/test/templates/linting_ok.mustache b/local/test/templates/linting_ok.mustache
+new file mode 100644
+index 0000000000..56f4ad6f1c
+--- /dev/null
++++ b/local/test/templates/linting_ok.mustache
+@@ -0,0 +1,53 @@
++{{!
++    This file is part of Moodle - http://moodle.org/
++
++    Moodle is free software: you can redistribute it and/or modify
++    it under the terms of the GNU General Public License as published by
++    the Free Software Foundation, either version 3 of the License, or
++    (at your option) any later version.
++
++    Moodle is distributed in the hope that it will be useful,
++    but WITHOUT ANY WARRANTY; without even the implied warranty of
++    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++    GNU General Public License for more details.
++
++    You should have received a copy of the GNU General Public License
++    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
++}}
++{{!
++    @template local_test/linting_ok
++
++    A test for for mustache linting tests.
++
++    Classes required for JS:
++    * none
++
++    Data attributes required for JS:
++    * none
++
++    Context variables required for this template:
++    * message A cleaned string (use clean_text()) to display.
++    * extraclasses Additional classes to apply to the notification.
++    * closebutton Whether a close button should be displayed to dismiss the message.
++    * announce Whether the notification should be announced to screen readers.
++
++    Example context (json):
++    {
++      "message": "Your pants are on fire!",
++      "closebutton": 1,
++      "announce": 1,
++      "extraclasses": "foo bar"
++    }
++}}
++<div class="alert alert-info alert-block fade in {{ extraclasses }}" {{!
++    }}{{# announce }} role="alert"{{/ announce }}{{!
++    }}>
++    {{# closebutton }}<button type="button" class="close" data-dismiss="alert">&times;</button>{{/ closebutton }}
++    {{{ message }}}
++</div>
++{{# js }}
++require(['jquery', 'theme_bootstrapbase/bootstrap'], function($) {
++    // Setup closing of bootstrap alerts.
++    $().alert();
++});
++{{/ js }}
+diff --git a/local/test/templates/local/mobile/view.mustache b/local/test/templates/local/mobile/view.mustache
+new file mode 100644
+index 0000000000..6db063b5f5
+--- /dev/null
++++ b/local/test/templates/local/mobile/view.mustache
+@@ -0,0 +1,41 @@
++{{!
++    This file is part of Moodle - http://moodle.org/
++
++    Moodle is free software: you can redistribute it and/or modify
++    it under the terms of the GNU General Public License as published by
++    the Free Software Foundation, either version 3 of the License, or
++    (at your option) any later version.
++
++    Moodle is distributed in the hope that it will be useful,
++    but WITHOUT ANY WARRANTY; without even the implied warranty of
++    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++    GNU General Public License for more details.
++
++    You should have received a copy of the GNU General Public License
++    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
++}}
++{{!
++    @template local_test/local/mobile/view
++
++    A test for for mustache linting tests. The file can be set to be excluded from the HTML validation part.
++
++    Classes required for JS:
++    * none
++
++    Data attributes required for JS:
++    * none
++
++    Context variables required for this template:
++    * arg string Argument.
++
++    Example context (json):
++    {
++      "arg": "Value"
++    }
++}}
++{{=<% %>=}}
++<span core-site-plugins-call-ws-on-load
++      name="local_test_method"
++      [params]="{arg: <% arg %>}"
++      [preSets]="{getFromCache: 0, saveToCache: 0}">
++</span>
+diff --git a/local/test/templates/mobile_view.mustache b/local/test/templates/mobile_view.mustache
+new file mode 100644
+index 0000000000..40eaa3e0f2
+--- /dev/null
++++ b/local/test/templates/mobile_view.mustache
+@@ -0,0 +1,41 @@
++{{!
++    This file is part of Moodle - http://moodle.org/
++
++    Moodle is free software: you can redistribute it and/or modify
++    it under the terms of the GNU General Public License as published by
++    the Free Software Foundation, either version 3 of the License, or
++    (at your option) any later version.
++
++    Moodle is distributed in the hope that it will be useful,
++    but WITHOUT ANY WARRANTY; without even the implied warranty of
++    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++    GNU General Public License for more details.
++
++    You should have received a copy of the GNU General Public License
++    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
++}}
++{{!
++    @template local_test/mobile_view
++
++    A test for for mustache linting tests. The file can be set to be excluded from the HTML validation part.
++
++    Classes required for JS:
++    * none
++
++    Data attributes required for JS:
++    * none
++
++    Context variables required for this template:
++    * arg string Argument.
++
++    Example context (json):
++    {
++      "arg": "Value"
++    }
++}}
++{{=<% %>=}}
++<span core-site-plugins-call-ws-on-load
++      name="local_test_method"
++      [params]="{arg: <% arg %>}"
++      [preSets]="{getFromCache: 0, saveToCache: 0}">
++</span>
+-- 
+2.26.2
+


### PR DESCRIPTION
When developing for the Moodle Mobile App, the Mustache templates may
contain Ionic3 / Angular specific syntax that itself is not valid HTML.
The patch adds an option to skip the HTML validation part of the
Mustache linting.
 
To ignore HTML validation errors, create a file `.mustachelintignore` in
the directory with Mustache templates and define the file name patterns
for the files to be excluded from HTML validation. PHP function
`fnmatch()` is used to search for matches. Lines starting with the hash
sign are considered as comments.