### PR TITLE
Warn about the migration to travis-ci.com when needed

### DIFF
--- a/tests/1-travis-branch-checker.bats
+++ b/tests/1-travis-branch-checker.bats
@@ -14,18 +14,29 @@ load libs/shared_setup
     assert_failure
 }
 
-@test "travis/check_branch_status.php: branch OK" {
-    # A branch which Dan has had integrated and won't touch again (and is protected for this purpose)
+@test "travis/check_branch_status.php: OK, but using old travis-ci.org" {
+    # A branch which Dan has had integrated and won't touch again (and is protected for this purpose). Using travis-ci.org
     ci_run_php travis/check_branch_status.php --repository=git://github.com/danpoltawski/moodle.git --branch=MDL-52127-master
     assert_success
-    assert_output 'OK: Build status was passed, see https://travis-ci.org/danpoltawski/moodle/builds/137772508'
+    assert_line 'WARNING: travis-ci.com integration not setup. See https://docs.moodle.org/dev/Travis_integration'
+    assert_line --partial 'WARNING: travis-ci.org integration working, but migration to travis-ci.com required.'
+    assert_line --partial '. See https://docs.moodle.org/dev/Travis_integration'
+    assert_line 'OK: Build status was passed, see https://travis-ci.org/danpoltawski/moodle/builds/137772508'
+}
+
+@test "travis/check_branch_status.php: branch OK, already using travis-ci.com" {
+    # A branch which Eloy has had integrated and won't touch again (and is protected for this purpose). Using travis-ci.com
+    ci_run_php travis/check_branch_status.php --repository=git://github.com/stronk7/moodle.git --branch=local_ci_test_travis_com
+    assert_success
+    assert_output 'OK: Build status was passed, see https://travis-ci.com/stronk7/moodle/builds/186304794'
 }
 
 @test "travis/check_branch_status.php: no travis setup" {
     # Use a moodlehq github repo which is unlikely to ever have travis integration.
     ci_run_php travis/check_branch_status.php --repository=https://github.com/moodlehq/moodle-theme_afterburner --branch=master
     assert_success
-    assert_output 'WARNING: Travis integration not setup. See https://docs.moodle.org/dev/Travis_Integration'
+    assert_line 'WARNING: travis-ci.com integration not setup. See https://docs.moodle.org/dev/Travis_integration'
+    assert_line 'WARNING: travis-ci.org integration not setup. See https://docs.moodle.org/dev/Travis_integration'
 }
 
 @test "travis/check_branch_status.php: not github repo" {

--- a/travis/check_branch_status.php
+++ b/travis/check_branch_status.php
@@ -60,41 +60,90 @@ $username = $matches[2];
 $reponame = $matches[3];
 $branchname = $options['branch'];
 
-$info = travis_api_request('/repos/'.$username.'/'.$reponame);
+// First, try travis-com.
+$info = travis_com_api_request('/repo/'.$username.'%2F'.$reponame);
 
-if (!isset($info->repo->active) || !$info->repo->active) {
-    echo "WARNING: Travis integration not setup. See https://docs.moodle.org/dev/Travis_Integration\n";
-    exit(0);
-}
+if (!isset($info->active) || !$info->active) {
+    echo "WARNING: travis-ci.com integration not setup. See https://docs.moodle.org/dev/Travis_integration\n";
 
-$json = travis_api_request('/repos/'.$username.'/'.$reponame.'/branches/'.$branchname);
-
-if (isset($json->branch->state)) {
-    $buildurl = 'https://travis-ci.org/'.$username.'/'.$reponame.'/builds/'.$json->branch->id;
-    switch ($json->branch->state) {
-        case 'failed':
-            echo 'ERROR: Build failed, see '.$buildurl."\n";
-            break;
-        case 'canceled':
-            echo 'WARNING: Build canceled, see '.$buildurl."\n";
-            break;
-        default:
-            echo "OK: Build status was {$json->branch->state}, see $buildurl\n";
-            break;
+    // Fallback to travis-ci.org, to see if that integration is setup.
+    // TODO: Remove all this and related org functions once travis-ci.org is completely gone.
+    $info = travis_org_api_request('/repos/'.$username.'/'.$reponame);
+    if (!isset($info->repo->active) || !$info->repo->active) {
+        echo "WARNING: travis-ci.org integration not setup. See https://docs.moodle.org/dev/Travis_integration\n";
+        exit(0);
+    } else {
+        // Recommend the migration to travis-ci.com.
+        echo "WARNING: travis-ci.org integration working, but migration to travis-ci.com required. See https://docs.moodle.org/dev/Travis_integration\n";
+        // Analyse travis-ci.org branch.
+        $json = travis_org_api_request('/repos/'.$username.'/'.$reponame.'/branches/'.$branchname);
+        analyse_branch_status('https://travis-ci.org', $username, $reponame,
+            $branchname, $json->branch->state, $json->branch->id);
     }
 } else {
-    // This could be because it doesn't exist.
-    echo "OK: Unknown state of $username/$reponame/$branchname\n";
+    // Analyse travis-ci.com branch.
+    $json = travis_com_api_request('/repo/'.$username.'%2F'.$reponame.'/branch/'.$branchname);
+    analyse_branch_status('https://travis-ci.com', $username, $reponame,
+        $branchname, $json->last_build->state, $json->last_build->id);
 }
+
 exit(0);
 
 /**
- * Does a GET request to travis api.
+ * Analyse data received about a branch (username, reponame, branchname, state, id).
+ *
+ * @param string $urlbase Base of the URL to link to.
+ * @param string $username Name of the owner.
+ * @param string $reponame Name of the repository.
+ * @param string $branchname Name of the branch.
+ * @param string $state Build status (from travis APIs).
+ * @param string $id Build id (from travis APIs).
+ */
+function analyse_branch_status($urlbase, $username, $reponame, $branchname, $state, $id) {
+    if (isset($state)) {
+        $buildurl = $urlbase . '/' . $username . '/' . $reponame . '/builds/' . $id;
+        switch ($state) {
+            case 'failed':
+                echo 'ERROR: Build failed, see '.$buildurl."\n";
+                break;
+            case 'canceled':
+                echo 'WARNING: Build canceled, see '.$buildurl."\n";
+                break;
+            default:
+                echo "OK: Build status was {$state}, see $buildurl\n";
+                break;
+        }
+    } else {
+        // This could be because it doesn't exist.
+        echo "OK: Unknown state of $username/$reponame/$branchname\n";
+    }
+}
+
+/**
+ * Does a GET request to travis-ci.com api.
  *
  * @param string $path the api path to call.
  * @return json_decoded response from the api
  */
-function travis_api_request($path) {
+function travis_com_api_request($path) {
+    $curl = curl_init();
+    curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 10);
+    curl_setopt($curl, CURLOPT_TIMEOUT, 10);
+    curl_setopt($curl, CURLOPT_HTTPHEADER, ['Travis-API-Version: 3']);
+    curl_setopt($curl, CURLOPT_URL, 'https://api.travis-ci.com'.$path);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+    $result = curl_exec($curl);
+    curl_close($curl);
+    return json_decode($result);
+}
+
+/**
+ * Does a GET request to travis-ci.org api.
+ *
+ * @param string $path the api path to call.
+ * @return json_decoded response from the api
+ */
+function travis_org_api_request($path) {
     $curl = curl_init();
     curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 10);
     curl_setopt($curl, CURLOPT_TIMEOUT, 10);


### PR DESCRIPTION
Part of MDLSITE-6246, this adds support to travis-ci.com
and warns when the "old" (to be stopped Dec 2020) travis-ci.org
is detected for a repo.

Covered with tests.