### PR TITLE
Ensure that no vendor dir is ever linted

### DIFF
--- a/php_lint/php_lint.sh
+++ b/php_lint/php_lint.sh
@@ -44,15 +44,21 @@ if [[ ${fulllint} -ne 1 ]]; then
 fi
 
 if [[ ${fulllint} -eq 1 ]]; then
-    mfiles=$(find $gitdir/ -name \*.php ! -path \*/vendor/\* | sed "s|$gitdir/||")
+    mfiles=$(find $gitdir/ -name \*.php | sed "s|$gitdir/||")
     echo "Running php syntax check on all files:"
 fi
 
 # Verify all the changed files.
 errorfound=0
 for mfile in ${mfiles} ; do
+
+    # Exclude any /vendor/ stuff. Always, no matter this is a full or commit run.
+    if [[ "${mfile}" =~ (^|/)vendor/ ]]; then
+        continue
+    fi
+
     # Only run on php files.
-    if [[ "${mfile}" =~ ".php" ]] ; then
+    if [[ "${mfile}" =~ .php$ ]] ; then
         fullpath=$gitdir/$mfile
 
         if [ -e $fullpath ] ; then

--- a/tests/1-php_lint.bats
+++ b/tests/1-php_lint.bats
@@ -36,6 +36,21 @@ setup () {
     assert_output --regexp "PHP syntax errors found."
 }
 
+@test "php_lint: Ensure vendor directories aren't checked ever" {
+    # Set up.
+    git_apply_fixture 31-php_lint-vendor.patch
+    export GIT_PREVIOUS_COMMIT=$FIXTURE_HASH_BEFORE
+    export GIT_COMMIT=$FIXTURE_HASH_AFTER
+
+    ci_run php_lint/php_lint.sh
+
+    # Assert result
+    assert_success
+    assert_output --partial "Running php syntax check from $GIT_PREVIOUS_COMMIT to $GIT_COMMIT"
+    assert_output --partial "No PHP syntax errors found"
+    refute_output --partial "vendor"
+}
+
 @test "php_lint: shows the php version being used" {
     # Set up.
     git_apply_fixture 31-php_lint-ok.patch

--- a/tests/fixtures/31-php_lint-vendor.patch
+++ b/tests/fixtures/31-php_lint-vendor.patch
@@ -1,0 +1,33 @@
+From d453b3f9d588c8d8355cfcc25a843c68d2afea0a Mon Sep 17 00:00:00 2001
+From: "Eloy Lafuente (stronk7)" <stronk7@moodle.org>
+Date: Thu, 24 Sep 2020 13:10:01 +0200
+Subject: [PATCH] Fixture for php_lint vendor tests
+
+---
+ lib/vendor/test.php | 3 +++
+ vendor/test.php     | 3 +++
+ 2 files changed, 6 insertions(+)
+ create mode 100644 lib/vendor/test.php
+ create mode 100644 vendor/test.php
+
+diff --git a/lib/vendor/test.php b/lib/vendor/test.php
+new file mode 100644
+index 0000000000..d075f480b6
+--- /dev/null
++++ b/lib/vendor/test.php
+@@ -0,0 +1,3 @@
++<?php
++
++echo "Oh, this breaks, badly!"
+diff --git a/vendor/test.php b/vendor/test.php
+new file mode 100644
+index 0000000000..d075f480b6
+--- /dev/null
++++ b/vendor/test.php
+@@ -0,0 +1,3 @@
++<?php
++
++echo "Oh, this breaks, badly!"
+-- 
+2.28.0
+


### PR DESCRIPTION
Previously we were excluding vendor directories
but only when "fullmode" (all files) were inspected.

Now this rule also applies to "intercommit" mode (only
files modified between 2 commits).

Covered with tests, checking both 1st level and inner
level vendor directories.