### PR TITLE
Ensure that eslint is called relative to the moodleroot

### DIFF
--- a/mustache_lint/js_helper.php
+++ b/mustache_lint/js_helper.php
@@ -64,7 +64,7 @@ class js_helper {
         ];
 
         $cmd = "$eslint --stdin --no-eslintrc --config {$this->moodleroot}/.eslintrc --format=json";
-        $proc = proc_open($cmd, $pipesspec, $pipes);
+        $proc = proc_open($cmd, $pipesspec, $pipes, $this->moodleroot);
         // Send the JS to stdin.
         fwrite($pipes[0], $this->js);
         fclose($pipes[0]);


### PR DESCRIPTION
ESLint searches for plugins relative to the CWD, and is unable to find
plugins when called from outside of the moodleroot, which the plugin
supports.