### PR TITLE
Accept return bool type hinting on upgrade functions

### DIFF
--- a/check_upgrade_savepoints/check_upgrade_savepoints.php
+++ b/check_upgrade_savepoints/check_upgrade_savepoints.php
@@ -60,7 +60,7 @@ foreach ($files as $file) {
 
     $contents = file_get_contents($file);
 
-    $function_regexp = '\s*function\s+xmldb_[a-zA-Z0-9_]+?_upgrade\s*\(.*?version.*?\)\s*(?=\{)';
+    $function_regexp = '\s*function\s+xmldb_[a-zA-Z0-9_]+?_upgrade\s*\(.*?version.*?\)(?::\sbool)?\s*(?=\{)';
     $return_regexp = '\s*return true;';
     $anyfunction_regexp = '\s*function\s*[a-z0-9_]+?\s*\(.*?\)\s*{'; // MDL-34103
 

--- a/tests/1-check_upgrade_savepoints.bats
+++ b/tests/1-check_upgrade_savepoints.bats
@@ -13,6 +13,17 @@ setup () {
     refute_output --partial 'ERROR:'
 }
 
+@test "check_upgrade_savepoints/check_upgrade_savepoints.sh: function returning bool" {
+    git_apply_fixture check_upgrade_savepoints/returning_bool.patch
+
+    ci_run check_upgrade_savepoints/check_upgrade_savepoints.sh
+    assert_success
+    run cat $WORKSPACE/check_upgrade_savepoints_MOODLE_31_STABLE.txt
+    refute_output --partial "ERROR"
+    refute_output --partial "WARN"
+    assert_output --partial "found 92 matching 'if' blocks and 'savepoint' calls"
+}
+
 @test "check_upgrade_savepoints/check_upgrade_savepoints.sh: blank upgrade file" {
     git_apply_fixture check_upgrade_savepoints/blank_upgrade_file.patch
 

--- a/tests/fixtures/check_upgrade_savepoints/returning_bool.patch
+++ b/tests/fixtures/check_upgrade_savepoints/returning_bool.patch
@@ -1,0 +1,25 @@
+From 2316d2cae62f8f8e63fe4be5bebdc8a15f5045d5 Mon Sep 17 00:00:00 2001
+From: "Eloy Lafuente (stronk7)" <stronk7@moodle.org>
+Date: Wed, 13 Jan 2021 17:21:41 +0100
+Subject: [PATCH] Return type hint in xmldb upgrade functions
+
+---
+ lib/db/upgrade.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/db/upgrade.php b/lib/db/upgrade.php
+index 685de9e34da..73493473b6e 100644
+--- a/lib/db/upgrade.php
++++ b/lib/db/upgrade.php
+@@ -84,7 +84,7 @@ defined('MOODLE_INTERNAL') || die();
+  * @param int $oldversion
+  * @return bool always true
+  */
+-function xmldb_main_upgrade($oldversion) {
++function xmldb_main_upgrade($oldversion): bool {
+     global $CFG, $DB;
+ 
+     require_once($CFG->libdir.'/db/upgradelib.php'); // Core Upgrade-related functions.
+-- 
+2.30.0
+


### PR DESCRIPTION
New xmldb_upgrade_xxxx() functions should start to come
with return (: bool) type hinting. We need to support that.

So I've added a non-capturing and optional group to the regexp matching the
function line and then everything continues working ok. Backed with test.