### PR TITLE
Add a new jobtype to launch all behat tests (goutte and chrome) together

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-dist: xenial
-
 language: php
 
-sudo: false
+os: linux
+dist: xenial
 
 addons:
   apt:
@@ -17,7 +16,7 @@ services:
   - mysql
 
 php:
-    - 7.2
+    - 7.3
 
 env:
     - TEST_SUITE="0-*"
@@ -26,11 +25,19 @@ env:
     - TEST_SUITE="3-*"
 
 install:
-  - git clone --depth 1 https://github.com/sstephenson/bats.git $HOME/bats
+  - git clone --depth 1 https://github.com/bats-core/bats-core.git $HOME/bats-core
   - nvm install 8.9
   - nvm use 8.9
   - travis_retry composer install
   - npm install
+  - echo -e "[server]\ninnodb_flush_log_at_trx_commit=0" | sudo tee -a /etc/mysql/my.cnf # General speed bump.
+  # Move MySQL data to tmpfs (see core travis). Without that we get random timeouts here and there.
+  - sudo mkdir /mnt/ramdisk
+  - sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
+  - sudo service mysql stop
+  - sudo mv /var/lib/mysql /mnt/ramdisk
+  - sudo ln -s /mnt/ramdisk/mysql /var/lib/mysql
+  - sudo service mysql restart
 
 before_script:
   - 'git config --global user.email "travis@localhost"'
@@ -48,4 +55,4 @@ before_script:
   - "unset _JAVA_OPTIONS" # stderr output on each java execution breaks our json expectations. See travis-ci/travis-ci#8408
 
 script:
-  - $HOME/bats/bin/bats tests/$TEST_SUITE
+  - $HOME/bats-core/bin/bats --timing tests/$TEST_SUITE

--- a/tests/1-compare_databases.bats
+++ b/tests/1-compare_databases.bats
@@ -37,18 +37,18 @@ setup () {
     assert_output --partial 'Error: dbtype environment variable is not defined. See the script comments.'
 }
 
-@test "compare_databases/compare_databases.sh: single actual (>= 35_STABLE) branch runs work" {
+@test "compare_databases/compare_databases.sh: single actual (>= 36_STABLE) branch runs work" {
     export gitbranchinstalled=master
-    export gitbranchupgraded=MOODLE_35_STABLE
+    export gitbranchupgraded=MOODLE_36_STABLE
 
     ci_run compare_databases/compare_databases.sh
     assert_success
-    assert_output --partial 'Info: Origin branches: (1) MOODLE_35_STABLE'
+    assert_output --partial 'Info: Origin branches: (1) MOODLE_36_STABLE'
     assert_output --partial 'Info: Target branch: master'
     assert_output --partial 'Info: Installing Moodle master into ci_installed_'
-    assert_output --partial 'Info: Comparing master and upgraded MOODLE_35_STABLE'
-    assert_output --partial 'Info: Installing Moodle MOODLE_35_STABLE into ci_upgraded_'
-    assert_output --partial 'Info: Upgrading Moodle MOODLE_35_STABLE to master into ci_upgraded_'
+    assert_output --partial 'Info: Comparing master and upgraded MOODLE_36_STABLE'
+    assert_output --partial 'Info: Installing Moodle MOODLE_36_STABLE into ci_upgraded_'
+    assert_output --partial 'Info: Upgrading Moodle MOODLE_36_STABLE to master into ci_upgraded_'
     assert_output --partial 'Info: Comparing databases ci_installed_'
     assert_output --partial 'Info: OK. No problems comparing databases ci_installed_'
     assert_output --partial 'Ok: Process ended without errors'
@@ -57,36 +57,36 @@ setup () {
     assert_success
 }
 
-@test "compare_databases/compare_databases.sh: single old (< 35_STABLE) branch runs work" {
-    export gitbranchinstalled=v3.4.5
-    export gitbranchupgraded=v3.4.1
+@test "compare_databases/compare_databases.sh: single old (< 37_STABLE) branch runs work" {
+    export gitbranchinstalled=v3.6.9
+    export gitbranchupgraded=v3.6.4
 
     ci_run compare_databases/compare_databases.sh
     assert_success
-    assert_output --partial 'Info: Origin branches: (1) v3.4.1'
-    assert_output --partial 'Info: Target branch: v3.4.5'
-    assert_output --partial 'Info: Installing Moodle v3.4.5 into ci_installed_'
-    assert_output --partial 'Info: Comparing v3.4.5 and upgraded v3.4.1'
-    assert_output --partial 'Info: Installing Moodle v3.4.1 into ci_upgraded_'
-    assert_output --partial 'Info: Upgrading Moodle v3.4.1 to v3.4.5 into ci_upgraded_'
+    assert_output --partial 'Info: Origin branches: (1) v3.6.4'
+    assert_output --partial 'Info: Target branch: v3.6.9'
+    assert_output --partial 'Info: Installing Moodle v3.6.9 into ci_installed_'
+    assert_output --partial 'Info: Comparing v3.6.9 and upgraded v3.6.4'
+    assert_output --partial 'Info: Installing Moodle v3.6.4 into ci_upgraded_'
+    assert_output --partial 'Info: Upgrading Moodle v3.6.4 to v3.6.9 into ci_upgraded_'
     assert_output --partial 'Info: Comparing databases ci_installed_'
     assert_output --partial 'Info: OK. No problems comparing databases ci_installed_'
     assert_output --partial 'Ok: Process ended without errors'
     refute_output --partial 'Error: Process ended with'
-    run [ -f $WORKSPACE/compare_databases_v3.4.5_logfile.txt ]
+    run [ -f $WORKSPACE/compare_databases_v3.6.9_logfile.txt ]
     assert_success
 }
 
 @test "compare_databases/compare_databases.sh: multiple branch runs work" {
     export gitbranchinstalled=master
-    export gitbranchupgraded=MOODLE_36_STABLE,MOODLE_37_STABLE
+    export gitbranchupgraded=MOODLE_39_STABLE,MOODLE_310_STABLE
 
     ci_run compare_databases/compare_databases.sh
     assert_success
-    assert_output --partial 'Info: Origin branches: (2) MOODLE_36_STABLE,MOODLE_37_STABLE'
+    assert_output --partial 'Info: Origin branches: (2) MOODLE_39_STABLE,MOODLE_310_STABLE'
     assert_output --partial 'Info: Target branch: master'
-    assert_output --partial 'Info: Comparing master and upgraded MOODLE_36_STABLE'
-    assert_output --partial 'Info: Comparing master and upgraded MOODLE_37_STABLE'
+    assert_output --partial 'Info: Comparing master and upgraded MOODLE_39_STABLE'
+    assert_output --partial 'Info: Comparing master and upgraded MOODLE_310_STABLE'
     assert_output --partial 'Ok: Process ended without errors'
     refute_output --partial 'Error: Process ended with'
     run [ -f $WORKSPACE/compare_databases_master_logfile.txt ]

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/jobs.sh
@@ -34,7 +34,7 @@ fi
 #fi
 
 # We want to launch always a Behat (goutte) job
-if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-goutte" ]]; then
+if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-goutte" ]]; then
 echo -n "Behat (goutte): " >> "${resultfile}.jenkinscli"
     ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
         -p REPOSITORY=${repository} \
@@ -46,7 +46,7 @@ echo -n "Behat (goutte): " >> "${resultfile}.jenkinscli"
 fi
 
 # We want to launch always a Behat (chrome) job
-if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-chrome" ]]; then
+if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-chrome" ]]; then
     echo -n "Behat (chrome): " >> "${resultfile}.jenkinscli"
     ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
         -p REPOSITORY=${repository} \


### PR DESCRIPTION
In many situations we want to run all behat tests, keeping phpunit apart
(specially because we run sqlsrv by default for better checking
cross-db).

This issue introduces a new behat-all job type that will behave exactly
that way. Trivial patch.

I've already configured [our jobs](https://ci.moodle.org/view/Tracker/job/TR%20-%20Bulk%20pre-launch%20DEV%20jobs%20(list_of_mdls)/) to show the new options there.