### PR TITLE
Ensure that the commits verifier split message lines properly

### DIFF
--- a/tests/1-verify_commit_messages.bats
+++ b/tests/1-verify_commit_messages.bats
@@ -93,6 +93,14 @@ commit_apply_fixture_and_run() {
     assert_output "${shorthash}*error*The line #3 has more than 132 characters (found: 181)"
 }
 
+@test "verify_commit_messages/verify_commit_messages.sh: backslash ended lines" {
+    commit_apply_fixture_and_run backslash-ended-lines.patch
+    assert_failure
+    refute_output "#3"
+    refute_output "#5"
+    assert_output "${shorthash}*error*The line #7 has more than 132 characters (found: 141)"
+}
+
 @test "verify_commit_messages/verify_commit_messages.sh: AMOS bad syntax" {
     commit_apply_fixture_and_run amos-bad-syntax.patch
     assert_failure

--- a/tests/fixtures/verify_commit_messages/backslash-ended-lines.patch
+++ b/tests/fixtures/verify_commit_messages/backslash-ended-lines.patch
@@ -1,0 +1,27 @@
+From 1e9449c06693c07c30b47f9c9589b99aae8d5479 Mon Sep 17 00:00:00 2001
+From: Dan Poltawski <dan@moodle.com>
+Date: Fri, 29 Jul 2016 12:54:22 +0100
+Subject: [PATCH 1/1] MDL-12345 summary: the first line is good!
+
+But then it all goes wrong, with a message that goes really quite \
+far down to the depths of the right hand side of the screen. This \
+person has never heard of wrapping text, sad eh!
+
+The above lines are correct, and shell won't expand those backslashes, but this line will fail for sure because it continues being too long.
+---
+ README.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/README.txt b/README.txt
+index 729dbe4..af81703 100644
+--- a/README.txt
++++ b/README.txt
+@@ -26,3 +26,5 @@ Moodle is written in PHP and JavaScript and uses an SQL database for storing
+ the data.
+ 
+ See <https://docs.moodle.org> for details of Moodle's many features.
++
++a dummy commit!
+-- 
+2.9.0
+

--- a/verify_commit_messages/verify_commit_messages.sh
+++ b/verify_commit_messages/verify_commit_messages.sh
@@ -137,7 +137,7 @@ for c in ${commits}; do
         currentline=1
         missingissuecode=""
         codearea=""
-        while read line; do
+        while IFS= read -r line; do
             # check 1st line
             if [[ ${currentline} -eq 1 ]]; then
                 # verify subject begins with template issue code + space. Error.


### PR DESCRIPTION
Before the patch, lines ended with backslash (\) were being
interpreted by bash and returned like one unique line,

Now, lines are returned 1 by 1 (ended with backslash) and
verified individually (so their lengths aren't aggregated).

Backed with test, to verify that the lines are handled individually.