### PR TITLE
Switch all ToBiC jobs to firefox (failing less right now than Chrome)

### DIFF
--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/jobs.sh
@@ -39,12 +39,12 @@ ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
     -p BROWSER=goutte \
     -w >> "${resultfile}.jenkinscli" < /dev/null
 
-# We want to launch always a Behat (chrome) job
-echo -n "Behat (chrome): " >> "${resultfile}.jenkinscli"
+# We want to launch always a Behat (firefox) job
+echo -n "Behat (firefox): " >> "${resultfile}.jenkinscli"
 ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
     -p REPOSITORY=${repository} \
     -p BRANCH=${branch} \
     -p DATABASE=pgsql \
     -p PHPVERSION=${php_version} \
-    -p BROWSER=chrome \
+    -p BROWSER=firefox \
     -w >> "${resultfile}.jenkinscli" < /dev/null

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/jobs.sh
@@ -45,14 +45,14 @@ echo -n "Behat (goutte): " >> "${resultfile}.jenkinscli"
         -w >> "${resultfile}.jenkinscli" < /dev/null
 fi
 
-# We want to launch always a Behat (chrome) job
-if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-chrome" ]]; then
-    echo -n "Behat (chrome): " >> "${resultfile}.jenkinscli"
+# We want to launch always a Behat (firefox) job
+if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-firefox" ]]; then
+    echo -n "Behat (firefox): " >> "${resultfile}.jenkinscli"
     ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
         -p REPOSITORY=${repository} \
         -p BRANCH=${branch} \
         -p DATABASE=pgsql \
         -p PHPVERSION=${php_version} \
-        -p BROWSER=chrome \
+        -p BROWSER=firefox \
         -w >> "${resultfile}.jenkinscli" < /dev/null
 fi

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls_sdev/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls_sdev/jobs.sh
@@ -39,12 +39,12 @@ ${jenkinsreq} "SDEV.01 - Developer-requested Behat" \
     -p BROWSER=goutte \
     -w >> "${resultfile}.jenkinscli" < /dev/null
 
-# We want to launch always a Behat (chrome) job
-echo -n "Behat (chrome): " >> "${resultfile}.jenkinscli"
+# We want to launch always a Behat (firefox) job
+echo -n "Behat (firefox): " >> "${resultfile}.jenkinscli"
 ${jenkinsreq} "SDEV.01 - Developer-requested Behat" \
     -p REPOSITORY=${repository} \
     -p BRANCH=${branch} \
     -p DATABASE=pgsql \
     -p PHPVERSION=${php_version} \
-    -p BROWSER=chrome \
+    -p BROWSER=firefox \
     -w >> "${resultfile}.jenkinscli" < /dev/null


### PR DESCRIPTION
Mainly because of the new Chrome 89 has come with some surprises, see:

https://tracker.moodle.org/browse/MDL-71108

But also because lately we were getting way less failures with Firefox
than with Chrome, we are switching all ToBiC jobs criteria to run
with Firefox.