### PR TITLE
Reset the ismasteronly flag for every issue being checked

### DIFF
--- a/tracker_automations/check_marked_as_integrated/check_marked_as_integrated.sh
+++ b/tracker_automations/check_marked_as_integrated/check_marked_as_integrated.sh
@@ -92,8 +92,8 @@ issues=() # The list of issues in current integration.
 # specified branches.
 ####
 issueslist=$( cat "${resultfile}" )
-ismasteronly=
 while read -r line; do
+    ismasteronly=
     issue=$( echo ${line} | sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' )
     issues+=($issue)
 


### PR DESCRIPTION
Today the first Moodle 4.0 only issue has landed, hence it
has got the first master-only label.

Problem is that such label was not being reset properly in the
loop and once set... it was applied to all subsequent issues.

By moving it to within the loop, we ensure it has the
correct default (empty/false) for every issue (unless
it's detected to be present).