### PR TITLE
Stop requiring Travis

### DIFF
--- a/tests/1-travis-branch-checker.bats
+++ b/tests/1-travis-branch-checker.bats
@@ -18,7 +18,7 @@ load libs/shared_setup
     # A branch which Dan has had integrated and won't touch again (and is protected for this purpose). Using travis-ci.org
     ci_run_php travis/check_branch_status.php --repository=git://github.com/danpoltawski/moodle.git --branch=MDL-52127-master
     assert_success
-    assert_line 'WARNING: travis-ci.com integration not setup. See https://docs.moodle.org/dev/Travis_integration'
+    assert_line 'SKIP: travis-ci.com integration not setup. See https://docs.moodle.org/dev/Travis_integration'
     assert_line --partial 'WARNING: travis-ci.org integration working, but migration to travis-ci.com required.'
     assert_line --partial '. See https://docs.moodle.org/dev/Travis_integration'
     assert_line 'OK: Build status was passed, see https://travis-ci.org/danpoltawski/moodle/builds/137772508'
@@ -35,8 +35,8 @@ load libs/shared_setup
     # Use a moodlehq github repo which is unlikely to ever have travis integration.
     ci_run_php travis/check_branch_status.php --repository=https://github.com/moodlehq/moodle-theme_afterburner --branch=master
     assert_success
-    assert_line 'WARNING: travis-ci.com integration not setup. See https://docs.moodle.org/dev/Travis_integration'
-    assert_line 'WARNING: travis-ci.org integration not setup. See https://docs.moodle.org/dev/Travis_integration'
+    assert_line 'SKIP: travis-ci.com integration not setup. See https://docs.moodle.org/dev/Travis_integration'
+    assert_line 'SKIP: travis-ci.org integration not setup. See https://docs.moodle.org/dev/Travis_integration'
 }
 
 @test "travis/check_branch_status.php: not github repo" {

--- a/travis/check_branch_status.php
+++ b/travis/check_branch_status.php
@@ -64,13 +64,13 @@ $branchname = $options['branch'];
 $info = travis_com_api_request('/repo/'.$username.'%2F'.$reponame);
 
 if (!isset($info->active) || !$info->active) {
-    echo "WARNING: travis-ci.com integration not setup. See https://docs.moodle.org/dev/Travis_integration\n";
+    echo "SKIP: travis-ci.com integration not setup. See https://docs.moodle.org/dev/Travis_integration\n";
 
     // Fallback to travis-ci.org, to see if that integration is setup.
     // TODO: Remove all this and related org functions once travis-ci.org is completely gone.
     $info = travis_org_api_request('/repos/'.$username.'/'.$reponame);
     if (!isset($info->repo->active) || !$info->repo->active) {
-        echo "WARNING: travis-ci.org integration not setup. See https://docs.moodle.org/dev/Travis_integration\n";
+        echo "SKIP: travis-ci.org integration not setup. See https://docs.moodle.org/dev/Travis_integration\n";
         exit(0);
     } else {
         // Recommend the migration to travis-ci.com.


### PR DESCRIPTION
Most people have moved away from Travis so we should stop warning if
it is not used.

THis change modifies the Travis integration tests to mark the test as
SKIPped if the integration is not setup. A warning is still used if
travis-ci.org is configured but not travis-ci.com.

Note: I have not written a Github Actions integration to replace this yet.