### PR TITLE
Allow to decide the target for the ToBiC comments

### DIFF
--- a/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
@@ -13,8 +13,9 @@
 #             Trios are colon separated, example: master:customfield_10111:7.3,....). All them required.
 #criteria: "awaiting integration"...
 #schedulemins: Frecuency (in minutes) of the schedule (cron) of this job. IMPORTANT to ensure that they match or there will be issues processed more than once or skipped.
-#jobtype: defaulting to "all", allows to just pick one of the available jobs: phpunit, behat-chrome, behat-goutte.
+#jobtype: defaulting to "all", allows to just pick one of the available jobs: phpunit, behat-chrome, behat-goutte, behat-all.
 #quiet: if enabled ("true"), don't perform any action in the Tracker.
+#restrictedto: name of the project (MDL) role we want to restrict the comment to. Blank means no restriction.
 
 
 # Let's go strict (exit on error)
@@ -142,6 +143,11 @@ while read issue; do
 
     # Execute the criteria postissue. It will perform the needed changes in the tracker for the current issue
     if [[ ${quiet} == "false" ]]; then
+        # Let's see if there is any restriction to the comment in the Tracker
+        commentrestriction=
+        if [[ -n "${restrictedto}" ]]; then
+            commentrestriction="--role \"$restrictedto\""
+        fi
         echo "  - Sending results to the Tracker"
         . "${mydir}/criteria/${criteria}/postissue.sh"
     fi

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/postissue.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/postissue.sh
@@ -1,5 +1,4 @@
 # Add the comment with results.
 ${basereq} --action addComment \
     --issue ${issue} \
-    --file "${resultfile}.${issue}.txt" \
-    --role "Integrators"
+    --file "${resultfile}.${issue}.txt" ${commentrestriction}

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/postissue.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/postissue.sh
@@ -1,5 +1,4 @@
 # Add the comment with results.
 ${basereq} --action addComment \
     --issue ${issue} \
-    --file "${resultfile}.${issue}.txt" \
-    --role "Integrators"
+    --file "${resultfile}.${issue}.txt" ${commentrestriction}

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls_sdev/postissue.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls_sdev/postissue.sh
@@ -1,5 +1,4 @@
 # Add the comment with results.
 ${basereq} --action addComment \
     --issue ${issue} \
-    --file "${resultfile}.${issue}.txt" \
-    --role "Integrators"
+    --file "${resultfile}.${issue}.txt" ${commentrestriction}


### PR DESCRIPTION
Right now, all the comments in the criteria are
harcoded to Integrators.

This change allow you to pick any other role in the project
with blank meaning visible to all.

The jobs @ ci.moodle.org has been already modified to support
this new parameter that will be configurable when any of the
jobs there are executed manually. By default, they continue
restricting to Integrators, until we decide to open them.

Local tests seem to work, but I've not been able to test the Tracker API call itself, so... cross fingers :-)