### PR TITLE
First cut of the normal queues manager

### DIFF
--- a/tracker_automations/continuous_manage_queues/continuous_manage_queues.sh
+++ b/tracker_automations/continuous_manage_queues/continuous_manage_queues.sh
@@ -29,7 +29,7 @@
 #      - Automated functional tests (behat)
 #      - Unit tests
 #
-# This job must be enabled only since freeze day to packaging day.
+# This job must be enabled only since freeze day to the end of on-sync period, when normal weeklies begin.
 #
 # Parameters:
 #  jiraclicmd: fill execution path of the jira cli

--- a/tracker_automations/normal_manage_queues/lib.sh
+++ b/tracker_automations/normal_manage_queues/lib.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Functions for normal_manage_queues.sh, look there
+# for details and nomenclature used.
+
+# Let's go strict (exit on error)
+set -e
+
+# Verify everything is set
+required="WORKSPACE jiraclicmd jiraserver jirauser jirapass"
+for var in $required; do
+    if [ -z "${!var}" ]; then
+        echo "Error: ${var} environment variable is not defined. See the script comments."
+        exit 1
+    fi
+done
+
+# A, move "important" issues from candidates to current
+function run_A() {
+    # Get the list of issues.
+    ${basereq} --action getIssueList \
+               --search "filter=14000
+                     AND NOT filter = 21366
+                     AND (
+                       filter = 21363 OR
+                       labels IN (mdlqa) OR
+                       priority IN (Critical, Blocker) OR
+                       level IS NOT EMPTY OR
+                       component IN ('Privacy', 'Automated functional tests (behat)', 'Unit tests')
+                     )" \
+               --file "${resultfile}"
+
+    # Iterate over found issues and perform the actions with them.
+    for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
+        echo "Processing ${issue}"
+        if [ -n "${dryrun}" ]; then
+            echo "Dry-run: $BUILD_NUMBER $BUILD_TIMESTAMP ${issue} moved to current: important"
+            continue
+        fi
+        # For fields available in the default screen, it's ok to use updateIssue or SetField, but in this case
+        # we are setting some custom fields not available (on purpose) on that screen. So we have created a
+        # global transition, only available to the bots, not transitioning but bringing access to all the fields
+        # via special screen. So we'll ne using that global transition via progressIssue instead.
+        # Also, there is one bug in the 4.4.x series, setting the destination as 0, leading to error in the
+        # execution, so the form was hacked in the browser to store correct -1: https://jira.atlassian.com/browse/JRA-25002
+        # Commented below, it's the "ideal" code. If some day JIRA changes that restriction we could stop using
+        # that non-transitional transition and use normal update.
+        #${basereq} --action updateIssue \
+        #    --issue ${issue} \
+        #    --custom "customfield_10110:,customfield_10210:,customfield_10211:Yes"
+        ${basereq} --action progressIssue \
+                   --issue ${issue} \
+                   --step "CI Global Self-Transition" \
+                   --custom "customfield_10211:Yes,customfield_10110:,customfield_10011:" \
+                   --comment "Normal queues manage: Moving to current because it's important" \
+                   --role "Integrators"
+        echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue} moved to current: important" >> "${logfile}"
+    done
+}
+
+# B, keep the current queue fed with bug issues when it's under a threshold.
+function run_B() {
+    # Count the list of issues in the current queue. (We cannot use getIssueCount till bumping to Jira CLI 8.1, hence, old way)
+    ${basereq} --action getIssueList \
+               --search "project = MDL \
+                     AND 'Currently in integration' IS NOT EMPTY \
+                     AND status IN ('Waiting for integration review')" \
+               --file "${resultfile}"
+
+    # Iterate over found issues just to count them.
+    counter=0
+    for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
+        counter=$((counter+1))
+    done
+    echo "$counter issues awaiting integration in current queue"
+
+    # If there are < $currentmin issues, let's add up to $movemax issues from the candidates queue.
+    if [[ "$counter" -lt "$currentmin" ]]; then
+        # Get an ordered list of up to $movemax issues in the candidate queue.
+        ${basereq} --action getIssueList \
+                   --limit $movemax \
+                   --search "filter=14000 \
+                       ORDER BY 'Integration priority' DESC, \
+                                priority DESC, \
+                                votes DESC, \
+                                'Last comment date' ASC" \
+                   --file "${resultfile}"
+
+        # Iterate over found issues, moving them to the current queue (cleaning integrator and tester).
+        for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
+            echo "Processing ${issue}"
+            if [ -n "${dryrun}" ]; then
+            echo "Dry-run: $BUILD_NUMBER $BUILD_TIMESTAMP ${issue} moved to current: threshold"
+                continue
+            fi
+            # For fields available in the default screen, it's ok to use updateIssue or SetField, but in this case
+            # we are setting some custom fields not available (on purpose) on that screen. So we have created a
+            # global transition, only available to the bots, not transitioning but bringing access to all the fields
+            # via special screen. So we'll ne using that global transition via progressIssue instead.
+            # Also, there is one bug in the 4.4.x series, setting the destination as 0, leading to error in the
+            # execution, so the form was hacked in the browser to store correct -1: https://jira.atlassian.com/browse/JRA-25002
+            # Commented below, it's the "ideal" code. If some day JIRA changes that restriction we could stop using
+            # that non-transitional transition and use normal update.
+            #${basereq} --action updateIssue \
+            #    --issue ${issue} \
+            #    --custom "customfield_10110:,customfield_10210:,customfield_10211:Yes"
+            ${basereq} --action progressIssue \
+                       --issue ${issue} \
+                       --step "CI Global Self-Transition" \
+                       --custom "customfield_10211:Yes,customfield_10110:,customfield_10011:" \
+                       --comment "Normal queues manage: Moving to current given we are below the threshold ($currentmin)" \
+                       --role "Integrators"
+            echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue} moved to current: threshold" >> "${logfile}"
+        done
+    fi
+}
+# C, raise the integration priority of issues awaiting too long in the candidates queue.
+function run_C() {
+    # Get the list of issues.
+    ${basereq} --action getIssueList \
+               --search "filter=14000
+                     AND 'Integration priority' = 0
+                     AND NOT status CHANGED AFTER -${waitingdays}d" \
+               --file "${resultfile}"
+
+    # Iterate over found issues and perform the actions with them.
+    for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
+        echo "Processing ${issue}"
+        if [ -n "${dryrun}" ]; then
+            echo "Dry-run: $BUILD_NUMBER $BUILD_TIMESTAMP ${issue} raised integration priority"
+            continue
+        fi
+        # For fields available in the default screen, it's ok to use updateIssue or SetField, but in this case
+        # we are setting some custom fields not available (on purpose) on that screen. So we have created a
+        # global transition, only available to the bots, not transitioning but bringing access to all the fields
+        # via special screen. So we'll ne using that global transition via progressIssue instead.
+        # Also, there is one bug in the 4.4.x series, setting the destination as 0, leading to error in the
+        # execution, so the form was hacked in the browser to store correct -1: https://jira.atlassian.com/browse/JRA-25002
+        # Commented below, it's the "ideal" code. If some day JIRA changes that restriction we could stop using
+        # that non-transitional transition and use normal update.
+        #${basereq} --action updateIssue \
+        #    --issue ${issue} \
+        #    --custom "customfield_10110:,customfield_10210:,customfield_10211:Yes"
+        ${basereq} --action progressIssue \
+                   --issue ${issue} \
+                   --step "CI Global Self-Transition" \
+                   --custom "customfield_12210:1" \
+                   --comment "Normal queues manage: Raising integration priority after ${waitingdays} days awaiting" \
+                   --role "Integrators"
+        echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue} raised integration priority" >> "${logfile}"
+    done
+}

--- a/tracker_automations/normal_manage_queues/normal_manage_queues.sh
+++ b/tracker_automations/normal_manage_queues/normal_manage_queues.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# This script adds some automatisms helping to manage the integration queues:
+#  - candidates queue: issues awaiting from integration not yet in current.
+#  - current queue: issues under current integration.
+#
+# The automatisms are as follow:
+#  A) Move "important" issues from candidates to current.
+#  B) Keep the current queue fed with issues from the candidates queue in rigorous priority order.
+#    - When the number of issues awaiting for integration falls below a threshold (currentmin).
+#    - Moving up to a maximum number of issue (movemax).
+#  C) Raise the integration priority of all the issues sitting in the candidates queue too long,
+#     in order to guarantee that they will be moved to current integration sooner.
+
+# The criteria to consider an issue "important" are:
+#  1) It must be in the candidates queue, awaiting for integration.       |
+#  2) It must not have the integration_held or security_held labels.      | => filter=14000
+#  3) It must not have the "agreed_to_be_after_release" text in a comment.| => NOT filter = 21366
+#  4) At least one of this is true:
+#    a) The issue has a must-fix version.                                 | => filter = 21363
+#    b) The issue has the mdlqa label.                                    | => labels IN (mdlqa)
+#    c) The issue priority is critical or higher.                         | => priority IN (Critical, Blocker)
+#    d) The issue is flagged as security issue.                           | => level IS NOT EMPTY
+#    e) The issue belongs to some of these components:                    | => component IN (...)
+#      - Privacy
+#      - Automated functional tests (behat)
+#      - Unit tests
+#
+# This job must be enabled over normal weeklies period (since end of on-sync to freeze).
+#
+# Parameters:
+#  jiraclicmd: fill execution path of the jira cli
+#  jiraserver: jira server url we are going to connect to
+#  jirauser: user that will perform the execution
+#  jirapass: password of the user
+#  currentmin: optional (dflt. 15), number of issue under which the current queue will be fed from the candidates one.
+#  movemax: optional (dflt. 3), max number of issue that will be moved from candidates to current when under currentmin.
+#  waitingdays: optional (dflt. 14), number of days an issue sits as candidate before its integraton priority is raised.
+#  dryrun: don't perfomr any write operation, only reads. Defaults to empty (false).
+
+# Let's go strict (exit on error)
+set -e
+
+# Verify everything is set
+required="WORKSPACE jiraclicmd jiraserver jirauser jirapass"
+for var in $required; do
+    if [ -z "${!var}" ]; then
+        echo "Error: ${var} environment variable is not defined. See the script comments."
+        exit 1
+    fi
+done
+
+# file where results will be sent
+resultfile=$WORKSPACE/normal_manage_queues.csv
+echo -n > "${resultfile}"
+
+# file where updated entries will be logged
+logfile=$WORKSPACE/normal_manage_queues.log
+
+# Calculate some variables
+mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+basereq="${jiraclicmd} --server ${jiraserver} --user ${jirauser} --password ${jirapass}"
+BUILD_TIMESTAMP="$(date +'%Y-%m-%d_%H-%M-%S')"
+
+source ${mydir}/lib.sh # Add all the functions.
+
+# Set defaults
+currentmin=${currentmin:-15}
+movemax=${movemax:-3}
+waitingdays=${waitingdays:-14}
+dryrun=${dryrun:-}
+
+if [ -n "${dryrun}" ]; then
+    echo "Dry-run enabled, no changes will be performed to the tracker"
+fi
+
+# A, move "important" issues from candidates to current.
+run_A
+
+# B, keep the current queue fed with issues when it's under a threshold.
+run_B
+
+# C, raise interation priority for issues awaiting as candidates too long.
+run_C
+
+# Remove the resultfile. We don't want to disclose those details.
+rm -fr "${resultfile}"


### PR DESCRIPTION
As discussed, the idea is to use this "normal periods" manager instead of the current "bulk-move on Mondays and bulk-delay on Thursdays (after cutoff)". Basically what we do in the continuous period, when the corresponding queues manager keeps us fed and does also other things (holding...). But the idea is to make issues "flow" instead of the current bulk way commented above.

If we perform this change still will have to:

1. #237 : see how we send the rebase message to issues already in continuous (because now they aren't going to be moved back to candidates).
2. ✔️ Agreed, like in continuous, also in the [integration exposed entries](https://moodle.org/mod/forum/discuss.php?d=422487#p1702271). Agree how we account status (like we do in continuous, queue sizes, basically) and report it.
3. ✔️ Decided, we don't delay issues (neither send a message) anymore.  Decide if we still send the "cutoff" message or no.
4. ⚠️ They are disabled for now, will remove them soon (once this is working ok). Completely remove the 2 "bulk" jobs ([Monday bulk move](https://ci.moodle.org/view/Tracker/job/TR%20-%20Move%20awaiting%20issues%20to%20current%20integration/) and [Thursday delay](https://ci.moodle.org/view/Tracker/job/TR%20-%20Delay%20awaiting%20issues/)) commented above.
5. ✔️ Done: Amend both [integration docs](https://docs.moodle.org/dev/index.php?title=Integration_Review&type=revision&diff=58891&oldid=58077) and [release process docs](https://docs.moodle.org/dev/index.php?title=Release_process&type=revision&diff=58886&oldid=58847).

----

Way simpler than the continuous one, only has to:

- Move "important" inssues to current.
- Keep current fed with issues when under a threshold.
- Raise the integration priority of issues waiting as candidates too long (configurable number of days).