### PR TITLE
Prevent scripts against some buggy JAVA en_AU locales

### DIFF
--- a/tracker_automations/count_delayed_last_cycle/count_delayed_last_cycle.sh
+++ b/tracker_automations/count_delayed_last_cycle/count_delayed_last_cycle.sh
@@ -76,6 +76,7 @@ done
 
 # get the contents of the integration date
 integrationjira=$( cat "${tempfile}" )
+integrationjira="${integrationjira//.}" # Some buggy Java AU locales come with dots in month names. Remove them.
 
 # if the last integration at jira has changed... start a new cycle
 if [ "${lastintegrationjira}" != "${integrationjira}" ]; then

--- a/tracker_automations/count_reopened_last_cycle/count_reopened_last_cycle.sh
+++ b/tracker_automations/count_reopened_last_cycle/count_reopened_last_cycle.sh
@@ -73,6 +73,7 @@ done
 
 # get the contents of the integration date
 integrationjira=$( cat "${tempfile}" )
+integrationjira="${integrationjira//.}" # Some buggy Java AU locales come with dots in month names. Remove them.
 
 # if the last integration at jira has changed... start a new cycle
 if [ "${lastintegrationjira}" != "${integrationjira}" ]; then

--- a/tracker_automations/count_test_failed_last_cycle/count_test_failed_last_cycle.sh
+++ b/tracker_automations/count_test_failed_last_cycle/count_test_failed_last_cycle.sh
@@ -73,6 +73,7 @@ done
 
 # get the contents of the integration date
 integrationjira=$( cat "${tempfile}" )
+integrationjira="${integrationjira//.}" # Some buggy Java AU locales come with dots in month names. Remove them.
 
 # if the last integration at jira has changed... start a new cycle
 if [ "${lastintegrationjira}" != "${integrationjira}" ]; then


### PR DESCRIPTION
From CLDR29 to CLDR33, the month and day names for en_AU were broken, incorrectly
adding a dot (.) after the day and month names. And it was fixed in CLDR34 . So I imagine
that java versions >=9 (when they changed from own locales to CLDR) that are using those CLDR
versions… are doomed (that for sure includes Java10).

Alternatively, there is the following switch:

`-Djava.locale.providers=COMPAT, CLDR`

to make Java own locales to be used instead of CLDR ones.

But as far as en_AU is already fixed in actual versions, we are simply
removing those incorrect dots fom the date fetched with Jira CLI and
done.

Some links:

- https://bugs.openjdk.java.net/browse/JDK-8208487