### PR TITLE
Raise priority of non-blocked blocker issues

### DIFF
--- a/tracker_automations/set_integration_priority_to_one/set_integration_priority_to_one.sh
+++ b/tracker_automations/set_integration_priority_to_one/set_integration_priority_to_one.sh
@@ -60,5 +60,71 @@ for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
     echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue}" >> "${logfile}"
 done
 
+# Now, let's look for all the issues, also having zero integration priority and
+# being under current integration or awaiting integration. Raise integration priority
+# for those being blockers of other issues and not being blocked by unresolved issue.
+#
+# Note that this can be achieved using a simple query using features provided by the J-Tricks
+# plugin (and others), but they won't be compatible with Jira Cloud instances, so we are doing
+# it using exclusively JiraCLI and its facilities (requiring multiple actions to be executed).
+
+# First, get all the issues that are blockers.
+${basereq} --action getIssueList \
+           --search "project = 'Moodle' \
+                 AND 'Integration priority' = 0 \
+                 AND ( \
+                       ('Currently in integration' = 'Yes' AND status != 'Reopened') \
+                       OR status = 'Waiting for integration review' \
+                     ) \
+                 AND issueLinkType = 'blocks'" \
+           --file "${resultfile}"
+
+# Iterate over found issues and get its list of links being "is blocked by"
+for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
+    echo "Processing ${issue}"
+    ${basereq} --action getLinkList \
+               --issue "${issue}" \
+               --columns "To Issue" \
+               --regex "(?i)is blocked by" \
+               --file "${resultfile}"
+
+    # Iterate over found "is blocked by" issues and concat them for the next query.
+    blockedbyissues=
+    for linkedissue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
+        blockedbyissues="${blockedbyissues} ${linkedissue},"
+    done
+    blockedbyissues=${blockedbyissues%?}
+
+    # Now let's see if any of the blockedby issues is unresolved.
+    # (note that, since JiraCLU 8.1, getIssueCount can be used instead, but we are using older)
+    if [[ -n ${blockedbyissues} ]]; then
+        ${basereq} --action getIssueList \
+                   --search "resolution = Unresolved AND issue IN (${blockedbyissues})" \
+                   --file "${resultfile}"
+        # If there are issues returned... then the issue still has unresolved blockers.
+        unresolvedfound=
+        for unresolvedissue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
+            echo "  ${linkedissue} blocks it and it is unresolved."
+            unresolvedfound=1
+        done
+
+        # If there are unresolved blockers, skip this issue.
+        if [[ -n ${unresolvedfound} ]]; then
+            echo "  skipping this issue"
+            echo
+            continue
+        fi
+    fi
+    # Arrived here, this is an issue that is blocking others but isn't blocked by any unresolved issue.
+    # So we raise its priority here and now.
+    echo "  Raising its integration priority to 1"
+    ${basereq} --action progressIssue \
+        --issue ${issue} \
+        --step "CI Global Self-Transition" \
+        --custom "customfield_12210:1"
+        echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue}" >> "${logfile}"
+    echo
+done
+
 # Remove the resultfile. We don't want to disclose those details.
 rm -fr "${resultfile}"


### PR DESCRIPTION
Now, all the issues that are blockers (blocks link type) to others and don't have
any unresolved blocking (is blocked by) issue, will get its integration
priority also raised to 1.

Done with pure JiraCLI, to allow it to work against any Jira server (we
won't be able to use some plugin that provides the same in an easier
way).

This has been already executed a number of times and seems to be working
correctly. Like 10-12 issues have got their priority raised. All them
non-blocked blockers.

Note that another follow-up will follow soon, about to lower the
priority of any issue that is blocked.