### PR TITLE
Lower priority blocked

### DIFF
--- a/tracker_automations/normal_manage_queues/lib.sh
+++ b/tracker_automations/normal_manage_queues/lib.sh
@@ -119,6 +119,7 @@ function run_C() {
     ${basereq} --action getIssueList \
                --search "filter=14000
                      AND 'Integration priority' = 0
+                     AND NOT (issueLinkType = 'blocks' OR issueLinkType = 'is blocked by')
                      AND NOT status CHANGED AFTER -${waitingdays}d" \
                --file "${resultfile}"
 

--- a/tracker_automations/normal_manage_queues/normal_manage_queues.sh
+++ b/tracker_automations/normal_manage_queues/normal_manage_queues.sh
@@ -9,7 +9,9 @@
 #    - When the number of issues awaiting for integration falls below a threshold (currentmin).
 #    - Moving up to a maximum number of issue (movemax).
 #  C) Raise the integration priority of all the issues sitting in the candidates queue too long,
-#     in order to guarantee that they will be moved to current integration sooner.
+#     in order to guarantee that they will be moved to current integration sooner. But avoid
+#     modifying the priority of any issue being blocked or blocking to others. This type of issues
+#     are managed exclusively by the set_integration_priority_to_[zero|one] scripts.
 
 # The criteria to consider an issue "important" are:
 #  1) It must be in the candidates queue, awaiting for integration.       |

--- a/tracker_automations/set_integration_priority_to_one/set_integration_priority_to_one.sh
+++ b/tracker_automations/set_integration_priority_to_one/set_integration_priority_to_one.sh
@@ -104,20 +104,21 @@ for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
         # If there are issues returned... then the issue still has unresolved blockers.
         unresolvedfound=
         for unresolvedissue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
-            echo "  ${linkedissue} blocks it and it is unresolved."
+            echo "  ${unresolvedissue} blocks it and it is unresolved."
             unresolvedfound=1
         done
 
         # If there are unresolved blockers, skip this issue.
         if [[ -n ${unresolvedfound} ]]; then
-            echo "  skipping this issue"
+            echo "  skipping this issue (has unresolved blockers)"
             echo
             continue
         fi
     fi
+
     # Arrived here, this is an issue that is blocking others but isn't blocked by any unresolved issue.
     # So we raise its priority here and now.
-    echo "  Raising its integration priority to 1"
+    echo "  Raising its integration priority to 1 (is blocker and has not unresolved blockers)"
     ${basereq} --action progressIssue \
         --issue ${issue} \
         --step "CI Global Self-Transition" \

--- a/tracker_automations/set_integration_priority_to_zero/set_integration_priority_to_zero.sh
+++ b/tracker_automations/set_integration_priority_to_zero/set_integration_priority_to_zero.sh
@@ -57,5 +57,72 @@ for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
     echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue}" >> "${logfile}"
 done
 
+# Now, let's look for all the issues, also having > 0 integration priority and
+# being under current integration or awaiting integration. Lower the integration
+# priority for those being blocked by unresolved issues.
+#
+# Note that this can be achieved using a simple query using features provided by the J-Tricks
+# plugin (and others), but they won't be compatible with Jira Cloud instances, so we are doing
+# it using exclusively JiraCLI and its facilities (requiring multiple actions to be executed).
+
+# First, get all the issues that are blocked by others.
+${basereq} --action getIssueList \
+           --search "project = 'Moodle' \
+                 AND 'Integration priority' > 0 \
+                 AND ( \
+                       ('Currently in integration' = 'Yes' AND status != 'Reopened') \
+                       OR status = 'Waiting for integration review' \
+                     ) \
+                 AND issueLinkType = 'is blocked by'" \
+           --file "${resultfile}"
+
+# Iterate over found issues and get its list of links being "is blocked by"
+for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
+    echo "Processing ${issue}"
+    ${basereq} --action getLinkList \
+               --issue "${issue}" \
+               --columns "To Issue" \
+               --regex "(?i)is blocked by" \
+               --file "${resultfile}"
+
+    # Iterate over found "is blocked by" issues and concat them for the next query.
+    blockedbyissues=
+    for linkedissue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
+        blockedbyissues="${blockedbyissues} ${linkedissue},"
+    done
+    blockedbyissues=${blockedbyissues%?}
+
+    # Now let's see if any of the blockedby issues is unresolved.
+    # (note that, since JiraCLU 8.1, getIssueCount can be used instead, but we are using older)
+    if [[ -n ${blockedbyissues} ]]; then
+        ${basereq} --action getIssueList \
+                   --search "resolution = Unresolved AND issue IN (${blockedbyissues})" \
+                   --file "${resultfile}"
+        # If there are issues returned... then the issue still has unresolved blockers.
+        unresolvedfound=
+        for unresolvedissue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
+            echo "  ${unresolvedissue} blocks it and it is unresolved."
+            unresolvedfound=1
+        done
+
+        # If there aren't unresolved blockers, skip this issue.
+        if [[ -z ${unresolvedfound} ]]; then
+            echo "  skipping this issue (all blockers are resolved)"
+            echo
+            continue
+        fi
+    fi
+
+    # Arrived here, this is an issue that is blocked by some unresolved issue.
+    # So we lower  its priority here and now.
+    echo "  lowering its integration priority to 0 (has unresolved blockers)"
+    ${basereq} --action progressIssue \
+        --issue ${issue} \
+        --step "CI Global Self-Transition" \
+        --custom "customfield_12210:0"
+        echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue}" >> "${logfile}"
+    echo
+done
+
 # Remove the resultfile. We don't want to disclose those details.
 rm -fr "${resultfile}"


### PR DESCRIPTION
This includes 2 commits:

- the first one about to implement in the "change to zero" script the ability to lower the priority for any issue being blocked by unresolved issues.
- the second, about prevent the normal queues manager to perform any change of priority on issues being "blockers" or "blocked", that's something that the set_integration_priority_to_[zero|one] scripts manage in exclusive.

The commit messages do include more details.

Potential TODO: together with changing the integration priority, also add a restricted (to integrators) message from CiBoT explaining why it has been decided to raise or lower the priority (the queues manager already does it, but the set_integration_priority_to_[zero|one] scripts do not. Not really sure if it's needed, so just commenting about it to gather opinions. Than can be done apart in any case, it's 3 lines change.