### PR TITLE
Add classic runs to ToBiC jobs

### DIFF
--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/jobs.sh
@@ -39,12 +39,23 @@ ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
     -p BROWSER=goutte \
     -w >> "${resultfile}.jenkinscli" < /dev/null
 
-# We want to launch always a Behat (firefox) job
-echo -n "Behat (firefox): " >> "${resultfile}.jenkinscli"
+# We want to launch always a Behat (firefox - boost) job
+echo -n "Behat (firefox - boost): " >> "${resultfile}.jenkinscli"
 ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
     -p REPOSITORY=${repository} \
     -p BRANCH=${branch} \
     -p DATABASE=pgsql \
     -p PHPVERSION=${php_version} \
     -p BROWSER=firefox \
+    -w >> "${resultfile}.jenkinscli" < /dev/null
+
+# We want to launch always a Behat (firefox - classic) job
+echo -n "Behat (firefox - classic): " >> "${resultfile}.jenkinscli"
+${jenkinsreq} "DEV.01 - Developer-requested Behat" \
+    -p REPOSITORY=${repository} \
+    -p BRANCH=${branch} \
+    -p DATABASE=pgsql \
+    -p PHPVERSION=${php_version} \
+    -p BROWSER=firefox \
+    -p BEHAT_SUITE=classic \
     -w >> "${resultfile}.jenkinscli" < /dev/null

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/jobs.sh
@@ -51,15 +51,29 @@ if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${job
         -w >> "${resultfile}.jenkinscli" < /dev/null
 fi
 
-# We want to launch always a Behat (firefox) job
+# We want to launch always a Behat (firefox - boost) job
 if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-firefox" ]]; then
-    echo -n "Behat (firefox): " >> "${resultfile}.jenkinscli"
+    echo -n "Behat (firefox - boost): " >> "${resultfile}.jenkinscli"
     ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
         -p REPOSITORY=${repository} \
         -p BRANCH=${branch} \
         -p DATABASE=pgsql \
         -p PHPVERSION=${php_version} \
         -p BROWSER=firefox \
+        -p RUNNERVERSION=${runner} \
+        -w >> "${resultfile}.jenkinscli" < /dev/null
+fi
+
+# We want to launch always a Behat (firefox - classic) job
+if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-firefox" ]]; then
+    echo -n "Behat (firefox - classic): " >> "${resultfile}.jenkinscli"
+    ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
+        -p REPOSITORY=${repository} \
+        -p BRANCH=${branch} \
+        -p DATABASE=pgsql \
+        -p PHPVERSION=${php_version} \
+        -p BROWSER=firefox \
+        -p BEHAT_SUITE=classic \
         -p RUNNERVERSION=${runner} \
         -w >> "${resultfile}.jenkinscli" < /dev/null
 fi

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls_sdev/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls_sdev/jobs.sh
@@ -51,15 +51,29 @@ if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${job
         -w >> "${resultfile}.jenkinscli" < /dev/null
 fi
 
-# We want to launch always a Behat (firefox) job
+# We want to launch always a Behat (firefox - boost) job
 if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-firefox" ]]; then
-    echo -n "Behat (firefox): " >> "${resultfile}.jenkinscli"
+    echo -n "Behat (firefox - boost): " >> "${resultfile}.jenkinscli"
     ${jenkinsreq} "SDEV.01 - Developer-requested Behat" \
         -p REPOSITORY=${repository} \
         -p BRANCH=${branch} \
         -p DATABASE=pgsql \
         -p PHPVERSION=${php_version} \
         -p BROWSER=firefox \
+        -p RUNNERVERSION=${runner} \
+        -w >> "${resultfile}.jenkinscli" < /dev/null
+fi
+
+# We want to launch always a Behat (firefox - classic) job
+if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-firefox" ]]; then
+    echo -n "Behat (firefox -classic): " >> "${resultfile}.jenkinscli"
+    ${jenkinsreq} "SDEV.01 - Developer-requested Behat" \
+        -p REPOSITORY=${repository} \
+        -p BRANCH=${branch} \
+        -p DATABASE=pgsql \
+        -p PHPVERSION=${php_version} \
+        -p BROWSER=firefox \
+        -p BEHAT_SUITE=classic \
         -p RUNNERVERSION=${runner} \
         -w >> "${resultfile}.jenkinscli" < /dev/null
 fi


### PR DESCRIPTION
With 4.0, boost is getting a lot of changes and we need to ensure
that classic continues ok. This adds a classic run to all ToBiC
runs (automated or manually invoked by integrators).