### PR TITLE
New upgrade_external_backup added to CiBoT

### DIFF
--- a/remote_branch_checker/checkstyle_converter.php
+++ b/remote_branch_checker/checkstyle_converter.php
@@ -37,7 +37,7 @@ list($options, $unrecognized) = cli_get_params(
 
 if ($unrecognized) {
     $unrecognized = implode("\n  ", $unrecognized);
-    cli_error("Unrecognised options:\n{$Unrecognised}\n Please use --help option.");
+    cli_error("Unrecognised options:\n{$unrecognised}\n Please use --help option.");
 
 }
 

--- a/remote_branch_checker/lib.php
+++ b/remote_branch_checker/lib.php
@@ -224,6 +224,23 @@ class remote_branch_reporter {
             }
         }
 
+        // Process the externalbackup missing stuff output, weighting errors with 5 and warnings with 1
+        $params = array(
+            'title' => 'Missing changes in external functions or backup support for new detected tables or columns',
+            'abbr' => 'externalbackup',
+            'description' => 'This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.',
+            'url' => 'https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app',
+            'codedir' => dirname($this->directory) . '/',
+            'errorweight' => 5,
+            'warningweight' => 1,
+            'allowfiltering' => 0);
+        if ($node = $this->apply_xslt($params, $this->directory . '/externalbackup.xml', 'checkstyle2smurf.xsl')) {
+            if ($check = $node->getElementsByTagName('check')->item(0)) {
+                $snode = $doc->importNode($check, true);
+                $smurf->appendChild($snode);
+            }
+        }
+
         // Process the unbuilt grunt output, weighting errors with 5 and warnings with 1
         $params = array(
             'title' => 'grunt changes',

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -361,6 +361,10 @@ echo "Info: Running thirdparty..."
 ${mydir}/../thirdparty_check/thirdparty_check.sh > "${WORKSPACE}/work/thirdparty.txt"
 cat "${WORKSPACE}/work/thirdparty.txt" | ${phpcmd} ${mydir}/checkstyle_converter.php --format=thirdparty > "${WORKSPACE}/work/thirdparty.xml"
 
+echo "Info: Running missing external/backup stuff..."
+${mydir}/../upgrade_external_backup_check/upgrade_external_backup_check.sh > "${WORKSPACE}/work/externalbackup.txt"
+cat "${WORKSPACE}/work/externalbackup.txt" | ${phpcmd} ${mydir}/checkstyle_converter.php --format=thirdparty > "${WORKSPACE}/work/externalbackup.xml"
+
 echo "Info: Running mustache lint..."
 ${mydir}/../mustache_lint/mustache_lint.sh > "${WORKSPACE}/work/mustachelint.txt"
 cat "${WORKSPACE}/work/mustachelint.txt" | ${phpcmd} ${mydir}/checkstyle_converter.php --format=mustachelint > "${WORKSPACE}/work/mustachelint.xml"

--- a/tests/1-upgrade_external_backup.bats
+++ b/tests/1-upgrade_external_backup.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+
+load libs/shared_setup
+
+setup () {
+    create_git_branch MOODLE_311_STABLE v3.11.0
+}
+
+@test "upgrade_external_backup: upgrade_external_backup_check no changes" {
+    git_apply_fixture 311-upgrade_external_backup-no-changes.patch
+    export initialcommit=$FIXTURE_HASH_BEFORE
+    export finalcommit=$FIXTURE_HASH_AFTER
+
+    ci_run upgrade_external_backup_check/upgrade_external_backup_check.sh
+    assert_success
+    assert_output --partial "INFO: Checking for DB modifications from $initialcommit to $finalcommit"
+    refute_output --partial "INFO: The patch does include new tables or columns"
+    assert_output --partial "INFO: OK the patch does not include new tables or columns"
+    refute_output --partial "WARN"
+}
+
+@test "upgrade_external_backup: upgrade_external_backup_check all wrong" {
+    git_apply_fixture 311-upgrade_external_backup-all-wrong.patch
+    export initialcommit=$FIXTURE_HASH_BEFORE
+    export finalcommit=$FIXTURE_HASH_AFTER
+
+    ci_run upgrade_external_backup_check/upgrade_external_backup_check.sh
+    assert_success
+    assert_output --partial "INFO: Checking for DB modifications from $initialcommit to $finalcommit"
+    assert_output --partial "INFO: The patch does include new tables or columns"
+    assert_output --partial "WARN: Database modifications (new tables or columns) detected"
+    assert_output --partial "WARN: No changes detected to external functions"
+    assert_output --partial "WARN: No changes detected to backup and restore"
+    refute_output --partial "INFO: OK the patch includes changes to both external and backup code"
+}
+
+@test "upgrade_external_backup: upgrade_external_backup_check backup ok" {
+    git_apply_fixture 311-upgrade_external_backup-backup-ok.patch
+    export initialcommit=$FIXTURE_HASH_BEFORE
+    export finalcommit=$FIXTURE_HASH_AFTER
+
+    ci_run upgrade_external_backup_check/upgrade_external_backup_check.sh
+    assert_success
+    assert_output --partial "INFO: Checking for DB modifications from $initialcommit to $finalcommit"
+    assert_output --partial "INFO: The patch does include new tables or columns"
+    assert_output --partial "WARN: Database modifications (new tables or columns) detected"
+    assert_output --partial "WARN: No changes detected to external functions"
+    refute_output --partial "WARN: No changes detected to backup and restore"
+    refute_output --partial "INFO: OK the patch includes changes to both external and backup code"
+}
+
+@test "upgrade_external_backup: upgrade_external_backup_check external ok" {
+    git_apply_fixture 311-upgrade_external_backup-external-ok.patch
+    export initialcommit=$FIXTURE_HASH_BEFORE
+    export finalcommit=$FIXTURE_HASH_AFTER
+
+    ci_run upgrade_external_backup_check/upgrade_external_backup_check.sh
+    assert_success
+    assert_output --partial "INFO: Checking for DB modifications from $initialcommit to $finalcommit"
+    assert_output --partial "INFO: The patch does include new tables or columns"
+    assert_output --partial "WARN: Database modifications (new tables or columns) detected"
+    refute_output --partial "WARN: No changes detected to external functions"
+    assert_output --partial "WARN: No changes detected to backup and restore"
+    refute_output --partial "INFO: OK the patch includes changes to both external and backup code"
+}
+
+@test "upgrade_external_backup: upgrade_external_backup_check all ok" {
+    git_apply_fixture 311-upgrade_external_backup-all-ok.patch
+    export initialcommit=$FIXTURE_HASH_BEFORE
+    export finalcommit=$FIXTURE_HASH_AFTER
+
+    ci_run upgrade_external_backup_check/upgrade_external_backup_check.sh
+    assert_success
+    assert_output --partial "INFO: Checking for DB modifications from $initialcommit to $finalcommit"
+    assert_output --partial "INFO: The patch does include new tables or columns"
+    refute_output --partial "WARN: Database modifications (new tables or columns) detected"
+    refute_output --partial "WARN: No changes detected to external functions"
+    refute_output --partial "WARN: No changes detected to backup and restore"
+    assert_output --partial "INFO: OK the patch includes changes to both external and backup code"
+}

--- a/tests/2-remote_branch_checker.bats
+++ b/tests/2-remote_branch_checker.bats
@@ -22,7 +22,6 @@ prepare_prechecker_npmbins () {
 }
 
 setup () {
-
     prepare_prechecker_npmbins
 
     create_git_branch MOODLE_34_STABLE v3.4.0 # Must be always a .0 version coz we precheck it in master.
@@ -80,6 +79,10 @@ assert_prechecker () {
     # Ensure stylelint doesn't complain about the third party css, but thirdpart does
     # TODO: thirdparty check bug with reporting same file twice..
     assert_prechecker fixture-thirdparty-css MDL-12345 665c3ac59c35b7387a4fc70b8ac6600ce9ffeb87
+}
+
+@test "remote_branch_checker/remote_branch_checker.sh: upgrade external backup" {
+    assert_prechecker local_ci_fixture_upgrade_external_backup MDL-12345 c69c33b14d9fb83ca22bde558169e36b5e1047cf
 }
 
 @test "remote_branch_checker/remote_branch_checker.sh: bad amos script" {

--- a/tests/fixtures/311-upgrade_external_backup-all-ok.patch
+++ b/tests/fixtures/311-upgrade_external_backup-all-ok.patch
@@ -1,0 +1,90 @@
+From d872bb3b4dbbc88f166425238746f9ba228ab7d5 Mon Sep 17 00:00:00 2001
+From: "Eloy Lafuente (stronk7)" <stronk7@moodle.org>
+Date: Sun, 14 Nov 2021 16:47:31 +0100
+Subject: [PATCH] NOBUG fixture: ALL OK upgrade_external_backup check
+
+---
+ mod/forum/backup/moodle2/backup_forum_stepslib.php |  2 +-
+ mod/forum/db/install.xml                           |  1 +
+ mod/forum/db/upgrade.php                           | 14 ++++++++++++++
+ mod/forum/externallib.php                          |  1 +
+ mod/forum/version.php                              |  2 +-
+ 5 files changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/mod/forum/backup/moodle2/backup_forum_stepslib.php b/mod/forum/backup/moodle2/backup_forum_stepslib.php
+index 8255dd81f74..600a2d3cbf0 100644
+--- a/mod/forum/backup/moodle2/backup_forum_stepslib.php
++++ b/mod/forum/backup/moodle2/backup_forum_stepslib.php
+@@ -39,7 +39,7 @@ class backup_forum_activity_structure_step extends backup_activity_structure_ste
+         // Define each element separated
+ 
+         $forum = new backup_nested_element('forum', array('id'), array(
+-            'type', 'name', 'intro', 'introformat', 'duedate', 'cutoffdate',
++            'bats', 'type', 'name', 'intro', 'introformat', 'duedate', 'cutoffdate',
+             'assessed', 'assesstimestart', 'assesstimefinish', 'scale',
+             'maxbytes', 'maxattachments', 'forcesubscribe', 'trackingtype',
+             'rsstype', 'rssarticles', 'timemodified', 'warnafter',
+diff --git a/mod/forum/db/install.xml b/mod/forum/db/install.xml
+index bbda97aba99..666a3923ecf 100644
+--- a/mod/forum/db/install.xml
++++ b/mod/forum/db/install.xml
+@@ -7,6 +7,7 @@
+     <TABLE NAME="forum" COMMENT="Forums contain and structure discussion">
+       <FIELDS>
+         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
++        <FIELD NAME="bats" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="general" SEQUENCE="false"/>
+         <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+         <FIELD NAME="type" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="general" SEQUENCE="false"/>
+         <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+diff --git a/mod/forum/db/upgrade.php b/mod/forum/db/upgrade.php
+index 505be0aaf52..8a51613e0dd 100644
+--- a/mod/forum/db/upgrade.php
++++ b/mod/forum/db/upgrade.php
+@@ -257,6 +257,20 @@ function xmldb_forum_upgrade($oldversion) {
+ 
+     // Automatically generated Moodle v3.10.0 release upgrade line.
+     // Put any upgrade step following this.
++    //
++    if ($oldversion < 2021051701) {
++
++        // Define field bats to be added to forum.
++        $table = new xmldb_table('forum');
++        $field = new xmldb_field('bats', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, 'bats', 'id');
++
++        // Conditionally launch add field wordcount.
++        if (!$dbman->field_exists($table, $field)) {
++            $dbman->add_field($table, $field);
++        }
++
++        upgrade_mod_savepoint(true, 2021051701, 'forum');
++    }
+ 
+     return true;
+ }
+diff --git a/mod/forum/externallib.php b/mod/forum/externallib.php
+index 407dc7096c6..7e0323f28b1 100644
+--- a/mod/forum/externallib.php
++++ b/mod/forum/externallib.php
+@@ -125,6 +125,7 @@ class mod_forum_external extends external_api {
+             new external_single_structure(
+                 array(
+                     'id' => new external_value(PARAM_INT, 'Forum id'),
++                    'bats' => new external_value(PARAM_TEXT, 'The forum bats'),
+                     'course' => new external_value(PARAM_INT, 'Course id'),
+                     'type' => new external_value(PARAM_TEXT, 'The forum type'),
+                     'name' => new external_value(PARAM_RAW, 'Forum name'),
+diff --git a/mod/forum/version.php b/mod/forum/version.php
+index 44579728cc6..2ed37326f54 100644
+--- a/mod/forum/version.php
++++ b/mod/forum/version.php
+@@ -24,6 +24,6 @@
+ 
+ defined('MOODLE_INTERNAL') || die();
+ 
+-$plugin->version   = 2021051700;       // The current module version (Date: YYYYMMDDXX).
++$plugin->version   = 2021051701;       // The current module version (Date: YYYYMMDDXX).
+ $plugin->requires  = 2021051100;       // Requires this Moodle version.
+ $plugin->component = 'mod_forum';      // Full name of the plugin (used for diagnostics)
+-- 
+2.33.1
+

--- a/tests/fixtures/311-upgrade_external_backup-all-wrong.patch
+++ b/tests/fixtures/311-upgrade_external_backup-all-wrong.patch
@@ -1,0 +1,63 @@
+From ec9e0ca9392379c1ec7b4246fa354b20f1189278 Mon Sep 17 00:00:00 2001
+From: "Eloy Lafuente (stronk7)" <stronk7@moodle.org>
+Date: Sun, 14 Nov 2021 16:47:31 +0100
+Subject: [PATCH] NOBUG fixture: ALL WRONG upgrade_external_backup check
+
+---
+ mod/forum/db/install.xml |  1 +
+ mod/forum/db/upgrade.php | 14 ++++++++++++++
+ mod/forum/version.php    |  2 +-
+ 3 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/mod/forum/db/install.xml b/mod/forum/db/install.xml
+index bbda97aba99..666a3923ecf 100644
+--- a/mod/forum/db/install.xml
++++ b/mod/forum/db/install.xml
+@@ -7,6 +7,7 @@
+     <TABLE NAME="forum" COMMENT="Forums contain and structure discussion">
+       <FIELDS>
+         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
++        <FIELD NAME="bats" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="general" SEQUENCE="false"/>
+         <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+         <FIELD NAME="type" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="general" SEQUENCE="false"/>
+         <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+diff --git a/mod/forum/db/upgrade.php b/mod/forum/db/upgrade.php
+index 505be0aaf52..8a51613e0dd 100644
+--- a/mod/forum/db/upgrade.php
++++ b/mod/forum/db/upgrade.php
+@@ -257,6 +257,20 @@ function xmldb_forum_upgrade($oldversion) {
+ 
+     // Automatically generated Moodle v3.10.0 release upgrade line.
+     // Put any upgrade step following this.
++    //
++    if ($oldversion < 2021051701) {
++
++        // Define field bats to be added to forum.
++        $table = new xmldb_table('forum');
++        $field = new xmldb_field('bats', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, 'bats', 'id');
++
++        // Conditionally launch add field wordcount.
++        if (!$dbman->field_exists($table, $field)) {
++            $dbman->add_field($table, $field);
++        }
++
++        upgrade_mod_savepoint(true, 2021051701, 'forum');
++    }
+ 
+     return true;
+ }
+diff --git a/mod/forum/version.php b/mod/forum/version.php
+index 44579728cc6..2ed37326f54 100644
+--- a/mod/forum/version.php
++++ b/mod/forum/version.php
+@@ -24,6 +24,6 @@
+ 
+ defined('MOODLE_INTERNAL') || die();
+ 
+-$plugin->version   = 2021051700;       // The current module version (Date: YYYYMMDDXX).
++$plugin->version   = 2021051701;       // The current module version (Date: YYYYMMDDXX).
+ $plugin->requires  = 2021051100;       // Requires this Moodle version.
+ $plugin->component = 'mod_forum';      // Full name of the plugin (used for diagnostics)
+-- 
+2.33.1
+

--- a/tests/fixtures/311-upgrade_external_backup-backup-ok.patch
+++ b/tests/fixtures/311-upgrade_external_backup-backup-ok.patch
@@ -1,0 +1,77 @@
+From 7e267ec7fa9dd29d268b09e0917e05f9076afcd2 Mon Sep 17 00:00:00 2001
+From: "Eloy Lafuente (stronk7)" <stronk7@moodle.org>
+Date: Sun, 14 Nov 2021 16:47:31 +0100
+Subject: [PATCH] NOBUG fixture: backup OK upgrade_external_backup check
+
+---
+ mod/forum/backup/moodle2/backup_forum_stepslib.php |  2 +-
+ mod/forum/db/install.xml                           |  1 +
+ mod/forum/db/upgrade.php                           | 14 ++++++++++++++
+ mod/forum/version.php                              |  2 +-
+ 4 files changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/mod/forum/backup/moodle2/backup_forum_stepslib.php b/mod/forum/backup/moodle2/backup_forum_stepslib.php
+index 8255dd81f74..600a2d3cbf0 100644
+--- a/mod/forum/backup/moodle2/backup_forum_stepslib.php
++++ b/mod/forum/backup/moodle2/backup_forum_stepslib.php
+@@ -39,7 +39,7 @@ class backup_forum_activity_structure_step extends backup_activity_structure_ste
+         // Define each element separated
+ 
+         $forum = new backup_nested_element('forum', array('id'), array(
+-            'type', 'name', 'intro', 'introformat', 'duedate', 'cutoffdate',
++            'bats', 'type', 'name', 'intro', 'introformat', 'duedate', 'cutoffdate',
+             'assessed', 'assesstimestart', 'assesstimefinish', 'scale',
+             'maxbytes', 'maxattachments', 'forcesubscribe', 'trackingtype',
+             'rsstype', 'rssarticles', 'timemodified', 'warnafter',
+diff --git a/mod/forum/db/install.xml b/mod/forum/db/install.xml
+index bbda97aba99..666a3923ecf 100644
+--- a/mod/forum/db/install.xml
++++ b/mod/forum/db/install.xml
+@@ -7,6 +7,7 @@
+     <TABLE NAME="forum" COMMENT="Forums contain and structure discussion">
+       <FIELDS>
+         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
++        <FIELD NAME="bats" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="general" SEQUENCE="false"/>
+         <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+         <FIELD NAME="type" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="general" SEQUENCE="false"/>
+         <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+diff --git a/mod/forum/db/upgrade.php b/mod/forum/db/upgrade.php
+index 505be0aaf52..8a51613e0dd 100644
+--- a/mod/forum/db/upgrade.php
++++ b/mod/forum/db/upgrade.php
+@@ -257,6 +257,20 @@ function xmldb_forum_upgrade($oldversion) {
+ 
+     // Automatically generated Moodle v3.10.0 release upgrade line.
+     // Put any upgrade step following this.
++    //
++    if ($oldversion < 2021051701) {
++
++        // Define field bats to be added to forum.
++        $table = new xmldb_table('forum');
++        $field = new xmldb_field('bats', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, 'bats', 'id');
++
++        // Conditionally launch add field wordcount.
++        if (!$dbman->field_exists($table, $field)) {
++            $dbman->add_field($table, $field);
++        }
++
++        upgrade_mod_savepoint(true, 2021051701, 'forum');
++    }
+ 
+     return true;
+ }
+diff --git a/mod/forum/version.php b/mod/forum/version.php
+index 44579728cc6..2ed37326f54 100644
+--- a/mod/forum/version.php
++++ b/mod/forum/version.php
+@@ -24,6 +24,6 @@
+ 
+ defined('MOODLE_INTERNAL') || die();
+ 
+-$plugin->version   = 2021051700;       // The current module version (Date: YYYYMMDDXX).
++$plugin->version   = 2021051701;       // The current module version (Date: YYYYMMDDXX).
+ $plugin->requires  = 2021051100;       // Requires this Moodle version.
+ $plugin->component = 'mod_forum';      // Full name of the plugin (used for diagnostics)
+-- 
+2.33.1
+

--- a/tests/fixtures/311-upgrade_external_backup-external-ok.patch
+++ b/tests/fixtures/311-upgrade_external_backup-external-ok.patch
@@ -1,0 +1,76 @@
+From 40ea7a869e990a506c768f639519acd91c744f5e Mon Sep 17 00:00:00 2001
+From: "Eloy Lafuente (stronk7)" <stronk7@moodle.org>
+Date: Sun, 14 Nov 2021 16:47:31 +0100
+Subject: [PATCH] NOBUG fixture: external OK upgrade_external_backup check
+
+---
+ mod/forum/db/install.xml  |  1 +
+ mod/forum/db/upgrade.php  | 14 ++++++++++++++
+ mod/forum/externallib.php |  1 +
+ mod/forum/version.php     |  2 +-
+ 4 files changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/mod/forum/db/install.xml b/mod/forum/db/install.xml
+index bbda97aba99..666a3923ecf 100644
+--- a/mod/forum/db/install.xml
++++ b/mod/forum/db/install.xml
+@@ -7,6 +7,7 @@
+     <TABLE NAME="forum" COMMENT="Forums contain and structure discussion">
+       <FIELDS>
+         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
++        <FIELD NAME="bats" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="general" SEQUENCE="false"/>
+         <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+         <FIELD NAME="type" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="general" SEQUENCE="false"/>
+         <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+diff --git a/mod/forum/db/upgrade.php b/mod/forum/db/upgrade.php
+index 505be0aaf52..8a51613e0dd 100644
+--- a/mod/forum/db/upgrade.php
++++ b/mod/forum/db/upgrade.php
+@@ -257,6 +257,20 @@ function xmldb_forum_upgrade($oldversion) {
+ 
+     // Automatically generated Moodle v3.10.0 release upgrade line.
+     // Put any upgrade step following this.
++    //
++    if ($oldversion < 2021051701) {
++
++        // Define field bats to be added to forum.
++        $table = new xmldb_table('forum');
++        $field = new xmldb_field('bats', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, 'bats', 'id');
++
++        // Conditionally launch add field wordcount.
++        if (!$dbman->field_exists($table, $field)) {
++            $dbman->add_field($table, $field);
++        }
++
++        upgrade_mod_savepoint(true, 2021051701, 'forum');
++    }
+ 
+     return true;
+ }
+diff --git a/mod/forum/externallib.php b/mod/forum/externallib.php
+index 407dc7096c6..7e0323f28b1 100644
+--- a/mod/forum/externallib.php
++++ b/mod/forum/externallib.php
+@@ -125,6 +125,7 @@ class mod_forum_external extends external_api {
+             new external_single_structure(
+                 array(
+                     'id' => new external_value(PARAM_INT, 'Forum id'),
++                    'bats' => new external_value(PARAM_TEXT, 'The forum bats'),
+                     'course' => new external_value(PARAM_INT, 'Course id'),
+                     'type' => new external_value(PARAM_TEXT, 'The forum type'),
+                     'name' => new external_value(PARAM_RAW, 'Forum name'),
+diff --git a/mod/forum/version.php b/mod/forum/version.php
+index 44579728cc6..2ed37326f54 100644
+--- a/mod/forum/version.php
++++ b/mod/forum/version.php
+@@ -24,6 +24,6 @@
+ 
+ defined('MOODLE_INTERNAL') || die();
+ 
+-$plugin->version   = 2021051700;       // The current module version (Date: YYYYMMDDXX).
++$plugin->version   = 2021051701;       // The current module version (Date: YYYYMMDDXX).
+ $plugin->requires  = 2021051100;       // Requires this Moodle version.
+ $plugin->component = 'mod_forum';      // Full name of the plugin (used for diagnostics)
+-- 
+2.33.1
+

--- a/tests/fixtures/311-upgrade_external_backup-no-changes.patch
+++ b/tests/fixtures/311-upgrade_external_backup-no-changes.patch
@@ -1,0 +1,70 @@
+From 432f063bdffb33c61f5e0df9c714273c5221dac6 Mon Sep 17 00:00:00 2001
+From: "Eloy Lafuente (stronk7)" <stronk7@moodle.org>
+Date: Sun, 14 Nov 2021 16:47:31 +0100
+Subject: [PATCH] NOBUG fixture: no changes upgrade_external_backup check
+
+---
+ mod/forum/backup/moodle2/backup_forum_stepslib.php | 2 +-
+ mod/forum/db/upgrade.php                           | 7 +++++++
+ mod/forum/externallib.php                          | 1 +
+ mod/forum/version.php                              | 2 +-
+ 4 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/mod/forum/backup/moodle2/backup_forum_stepslib.php b/mod/forum/backup/moodle2/backup_forum_stepslib.php
+index 8255dd81f74..600a2d3cbf0 100644
+--- a/mod/forum/backup/moodle2/backup_forum_stepslib.php
++++ b/mod/forum/backup/moodle2/backup_forum_stepslib.php
+@@ -39,7 +39,7 @@ class backup_forum_activity_structure_step extends backup_activity_structure_ste
+         // Define each element separated
+ 
+         $forum = new backup_nested_element('forum', array('id'), array(
+-            'type', 'name', 'intro', 'introformat', 'duedate', 'cutoffdate',
++            'bats', 'type', 'name', 'intro', 'introformat', 'duedate', 'cutoffdate',
+             'assessed', 'assesstimestart', 'assesstimefinish', 'scale',
+             'maxbytes', 'maxattachments', 'forcesubscribe', 'trackingtype',
+             'rsstype', 'rssarticles', 'timemodified', 'warnafter',
+diff --git a/mod/forum/db/upgrade.php b/mod/forum/db/upgrade.php
+index 505be0aaf52..2c29a2d714c 100644
+--- a/mod/forum/db/upgrade.php
++++ b/mod/forum/db/upgrade.php
+@@ -257,6 +257,13 @@ function xmldb_forum_upgrade($oldversion) {
+ 
+     // Automatically generated Moodle v3.10.0 release upgrade line.
+     // Put any upgrade step following this.
++    //
++    if ($oldversion < 2021051701) {
++
++        // Let's do something here, like updating something or so, but without DDL.
++
++        upgrade_mod_savepoint(true, 2021051701, 'forum');
++    }
+ 
+     return true;
+ }
+diff --git a/mod/forum/externallib.php b/mod/forum/externallib.php
+index 407dc7096c6..7e0323f28b1 100644
+--- a/mod/forum/externallib.php
++++ b/mod/forum/externallib.php
+@@ -125,6 +125,7 @@ class mod_forum_external extends external_api {
+             new external_single_structure(
+                 array(
+                     'id' => new external_value(PARAM_INT, 'Forum id'),
++                    'bats' => new external_value(PARAM_TEXT, 'The forum bats'),
+                     'course' => new external_value(PARAM_INT, 'Course id'),
+                     'type' => new external_value(PARAM_TEXT, 'The forum type'),
+                     'name' => new external_value(PARAM_RAW, 'Forum name'),
+diff --git a/mod/forum/version.php b/mod/forum/version.php
+index 44579728cc6..2ed37326f54 100644
+--- a/mod/forum/version.php
++++ b/mod/forum/version.php
+@@ -24,6 +24,6 @@
+ 
+ defined('MOODLE_INTERNAL') || die();
+ 
+-$plugin->version   = 2021051700;       // The current module version (Date: YYYYMMDDXX).
++$plugin->version   = 2021051701;       // The current module version (Date: YYYYMMDDXX).
+ $plugin->requires  = 2021051100;       // Requires this Moodle version.
+ $plugin->component = 'mod_forum';      // Full name of the plugin (used for diagnostics)
+-- 
+2.33.1
+

--- a/tests/fixtures/remote_branch_checker/MDL-53572-master-8ce58c9.xml
+++ b/tests/fixtures/remote_branch_checker/MDL-53572-master-8ce58c9.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="0" numwarnings="0">
-  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -9,6 +9,7 @@
     <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
     <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
@@ -45,6 +46,10 @@
   </check>
   <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
     <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.</description>
     <mess/>
   </check>
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-bad-amos-commands.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-bad-amos-commands.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="2" numwarnings="0">
-  <summary status="error" numerrors="2" numwarnings="0" condensedresult="smurf,error,2,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,error,2,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="error" numerrors="2" numwarnings="0" condensedresult="smurf,error,2,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,error,2,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -9,6 +9,7 @@
     <detail name="commit" status="error" numerrors="2" numwarnings="0"/>
     <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
@@ -61,6 +62,10 @@
   </check>
   <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
     <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.</description>
     <mess/>
   </check>
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-gherkin-lint.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-gherkin-lint.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="4" numwarnings="1">
-  <summary status="error" numerrors="4" numwarnings="1" condensedresult="smurf,error,4,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,error,3,0">
+  <summary status="error" numerrors="4" numwarnings="1" condensedresult="smurf,error,4,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,error,3,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -9,6 +9,7 @@
     <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
     <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="error" numerrors="1" numwarnings="1"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
@@ -45,6 +46,10 @@
   </check>
   <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
     <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.</description>
     <mess/>
   </check>
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="1" numwarnings="1" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-grunt-build-failed.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-grunt-build-failed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="3" numwarnings="1">
-  <summary status="error" numerrors="3" numwarnings="1" condensedresult="smurf,error,3,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,2,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="error" numerrors="3" numwarnings="1" condensedresult="smurf,error,3,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,2,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -9,6 +9,7 @@
     <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
     <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="error" numerrors="1" numwarnings="1"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
@@ -56,6 +57,10 @@
   </check>
   <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
     <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.</description>
     <mess/>
   </check>
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="1" numwarnings="1" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-mustache-lint-js.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-mustache-lint-js.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="0" numwarnings="2">
-  <summary status="warning" numerrors="0" numwarnings="2" condensedresult="smurf,warning,0,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,warning,0,2;gherkin,success,0,0">
+  <summary status="warning" numerrors="0" numwarnings="2" condensedresult="smurf,warning,0,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,warning,0,2;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -9,6 +9,7 @@
     <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
     <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
@@ -45,6 +46,10 @@
   </check>
   <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
     <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.</description>
     <mess/>
   </check>
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-mustache-lint.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-mustache-lint.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="1" numwarnings="4">
-  <summary status="error" numerrors="1" numwarnings="4" condensedresult="smurf,error,1,4:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,error,1,4;gherkin,success,0,0">
+  <summary status="error" numerrors="1" numwarnings="4" condensedresult="smurf,error,1,4:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,error,1,4;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -9,6 +9,7 @@
     <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
     <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
@@ -45,6 +46,10 @@
   </check>
   <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
     <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.</description>
     <mess/>
   </check>
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-non-code-update.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-non-code-update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="0" numwarnings="0">
-  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -9,6 +9,7 @@
     <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
     <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
@@ -45,6 +46,10 @@
   </check>
   <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
     <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.</description>
     <mess/>
   </check>
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-thirdparty-css.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-thirdparty-css.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="0" numwarnings="2">
-  <summary status="warning" numerrors="0" numwarnings="2" condensedresult="smurf,warning,0,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,warning,0,2;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="warning" numerrors="0" numwarnings="2" condensedresult="smurf,warning,0,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,warning,0,2;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -9,6 +9,7 @@
     <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
     <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="thirdparty" status="warning" numerrors="0" numwarnings="2"/>
+    <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
@@ -57,6 +58,10 @@
         <code/>
       </problem>
     </mess>
+  </check>
+  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.</description>
+    <mess/>
   </check>
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="0" numwarnings="0" allowfiltering="0">
     <description>This section shows files built by grunt and not commited</description>

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_manyproblems.xml
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_manyproblems.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="11" numwarnings="6">
-  <summary status="error" numerrors="11" numwarnings="6" condensedresult="smurf,error,11,6:phplint,error,1,0;phpcs,error,2,2;js,error,1,1;css,error,3,0;phpdoc,success,0,0;commit,error,1,1;savepoint,error,2,0;thirdparty,warning,0,1;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="error" numerrors="11" numwarnings="6" condensedresult="smurf,error,11,6:phplint,error,1,0;phpcs,error,2,2;js,error,1,1;css,error,3,0;phpdoc,success,0,0;commit,error,1,1;savepoint,error,2,0;thirdparty,warning,0,1;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="error" numerrors="1" numwarnings="0"/>
     <detail name="phpcs" status="error" numerrors="2" numwarnings="2"/>
     <detail name="js" status="error" numerrors="1" numwarnings="1"/>
@@ -9,6 +9,7 @@
     <detail name="commit" status="error" numerrors="1" numwarnings="1"/>
     <detail name="savepoint" status="error" numerrors="2" numwarnings="0"/>
     <detail name="thirdparty" status="warning" numerrors="0" numwarnings="1"/>
+    <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="error" numerrors="1" numwarnings="1"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
@@ -128,6 +129,10 @@
         <code/>
       </problem>
     </mess>
+  </check>
+  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.</description>
+    <mess/>
   </check>
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="1" numwarnings="1" allowfiltering="0">
     <description>This section shows files built by grunt and not commited</description>

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_oldbranch.xml
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_oldbranch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="4" numwarnings="7">
-  <summary status="error" numerrors="4" numwarnings="7" condensedresult="smurf,error,4,7:phplint,success,0,0;phpcs,success,0,0;js,warning,0,6;css,success,0,0;phpdoc,success,0,0;commit,error,3,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0">
+  <summary status="error" numerrors="4" numwarnings="7" condensedresult="smurf,error,4,7:phplint,success,0,0;phpcs,success,0,0;js,warning,0,6;css,success,0,0;phpdoc,success,0,0;commit,error,3,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="warning" numerrors="0" numwarnings="6"/>
@@ -9,6 +9,7 @@
     <detail name="commit" status="error" numerrors="3" numwarnings="0"/>
     <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="error" numerrors="1" numwarnings="1"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
@@ -91,6 +92,10 @@
   </check>
   <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
     <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.</description>
     <mess/>
   </check>
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="1" numwarnings="1" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_external_backup.xml
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_external_backup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<smurf version="0.9.1" numerrors="0" numwarnings="0">
-  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+<smurf version="0.9.1" numerrors="0" numwarnings="3">
+  <summary status="warning" numerrors="0" numwarnings="3" condensedresult="smurf,warning,0,3:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,warning,0,3;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -9,7 +9,7 @@
     <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
     <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="externalbackup" status="warning" numerrors="0" numwarnings="3"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
@@ -38,13 +38,7 @@
   </check>
   <check id="commit" title="Commit messages problems" url="https://docs.moodle.org/dev/Commit_cheat_sheet#Provide_clear_commit_messages" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows the problems detected in the commit messages by the commits checker</description>
-    <mess>
-      <problem file="c8c8470b8c" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/commit/c8c8470b8c" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Commit_cheat_sheet#Provide_clear_commit_messages" type="info" weight="1">
-        <message>AMOS - String to be copied: searchengine/admin to type_search/plugin </message>
-        <description/>
-        <code/>
-      </problem>
-    </mess>
+    <mess/>
   </check>
   <check id="savepoint" title="Update savepoints problems" url="https://docs.moodle.org/dev/Upgrade_API" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected with the handling of upgrade savepoints</description>
@@ -54,9 +48,25 @@
     <description>This section shows problems detected with the modification of third party libraries</description>
     <mess/>
   </check>
-  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="0" allowfiltering="0">
+  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="3" allowfiltering="0">
     <description>This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.</description>
-    <mess/>
+    <mess>
+      <problem file="mod/forum/db/upgrade.php" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/129efea5f8ddb304f993222adc053829d4506ba7/mod/forum/db/upgrade.php#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" type="warning" weight="1">
+        <message>Database modifications (new tables or columns) detected in the patch without any change to some important areas. </message>
+        <description/>
+        <code/>
+      </problem>
+      <problem file="mod/forum/db/upgrade.php" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/129efea5f8ddb304f993222adc053829d4506ba7/mod/forum/db/upgrade.php#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" type="warning" weight="1">
+        <message>No changes detected to external functions, that may affect apps and other web service integrations, please verify! </message>
+        <description/>
+        <code/>
+      </problem>
+      <problem file="mod/forum/db/upgrade.php" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/129efea5f8ddb304f993222adc053829d4506ba7/mod/forum/db/upgrade.php#L0" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" type="warning" weight="1">
+        <message>No changes detected to backup and restore, that may affect storage and transportability, please verify! </message>
+        <description/>
+        <code/>
+      </problem>
+    </mess>
   </check>
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="0" numwarnings="0" allowfiltering="0">
     <description>This section shows files built by grunt and not commited</description>

--- a/tests/fixtures/remote_branch_checker/prechecker-fixture-stylelint.xml
+++ b/tests/fixtures/remote_branch_checker/prechecker-fixture-stylelint.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="5" numwarnings="2">
-  <summary status="error" numerrors="5" numwarnings="2" condensedresult="smurf,error,5,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,4,1;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="error" numerrors="5" numwarnings="2" condensedresult="smurf,error,5,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,4,1;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -9,6 +9,7 @@
     <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
     <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="error" numerrors="1" numwarnings="1"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
     <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
@@ -71,6 +72,10 @@
   </check>
   <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
     <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.</description>
     <mess/>
   </check>
   <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="1" numwarnings="1" allowfiltering="0">

--- a/upgrade_external_backup_check/upgrade_external_backup_check.sh
+++ b/upgrade_external_backup_check/upgrade_external_backup_check.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# $WORKSPACE: Path to the directory where test reults will be sent
+# $phpcmd: Path to the PHP CLI executable
+# $gitcmd: Path to the git CLI executable
+# $gitdir: Directory containing git repo
+# $initalcommit
+# $finalcommit
+
+set -e
+
+# Verify everything is set
+required="WORKSPACE phpcmd gitcmd gitdir initialcommit finalcommit"
+for var in $required; do
+    if [ -z "${!var}" ]; then
+        echo "ERROR: ${var} environment variable is not defined. See the script comments."
+        exit 1
+    fi
+done
+
+# calculate some variables
+mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if ${mydir}/../list_changed_files/list_changed_files.sh > ${WORKSPACE}/modified_files.txt
+then
+    echo "INFO: Checking for DB modifications from $initialcommit to $finalcommit"
+else
+    echo "ERROR: Problems getting the list of changed files."
+    exit 1
+fi
+
+cd "${gitdir}"
+
+installfound=
+installcols=
+upgradefound=
+upgradefiles=
+externalfound=
+backupfound=
+
+# Simply, iterate over the modified files, annotating what's found.
+# We could do this more selectively, by components, instead of globally
+# but, as far as this is only a warning, we don't need such granularity.
+while read modifiedfile; do
+    if [[ "${modifiedfile}" =~ db/install\.xml ]]; then
+        # Try to find new columns added
+        installcols=$($gitcmd diff $initialcommit $finalcommit ${modifiedfile} | sed -nr 's/^\+ *<(TABLE|FIELD) *NAME="([^"]+)".*/\2/p')
+        if [[ -n ${installcols} ]]; then
+            installfound=1
+        fi
+    fi
+    if [[ "${modifiedfile}" =~ db/upgrade\.php ]]; then
+        # Verify if there are new tables or columns being added.
+        if [[ $($gitcmd diff $initialcommit $finalcommit ${modifiedfile} | grep 'add_field\|add_table') ]]; then
+            upgradefound=1
+            upgradefile=${gitdir}/${modifiedfile}
+        fi
+    fi
+    if [[ "${modifiedfile}" =~ externallib\.php|/classes/external/ ]]; then
+        externalfound=1
+    fi
+    if [[ "${modifiedfile}" =~ /backup/moodle2/ ]]; then
+        backupfound=1
+    fi
+
+done <$WORKSPACE/modified_files.txt
+
+# If we haven't found install and upgrade modifications adding columns or tables, everything is ok, we are done.
+if [[ -z ${installfound} ]] || [[ -z ${upgradefound} ]]; then
+    echo "INFO: OK the patch does not include new tables or columns"
+    exit 0
+fi
+
+# Arrived here, we have found new tables or columns coming in the patch. Let's look for usual missing stuff.
+echo "INFO: The patch does include new tables or columns"
+
+if [[ -z ${externalfound} ]] || [[ -z ${backupfound} ]]; then
+    echo "${upgradefile} - WARN: Database modifications (new tables or columns) detected in the patch without any change to some important areas."
+
+    if [[ -z ${externalfound} ]]; then
+        echo "${upgradefile} - WARN: No changes detected to external functions, that may affect apps and other web service integrations, please verify!"
+        warnedout=1
+    fi
+
+    if [[ -z ${backupfound} ]]; then
+        echo "${upgradefile} - WARN: No changes detected to backup and restore, that may affect storage and transportability, please verify!"
+    fi
+else
+    echo "INFO: OK the patch includes changes to both external and backup code"
+fi
+
+exit 0


### PR DESCRIPTION
New check looking for missing modifications in external/backup when there are new columns added to DB in upgrade.

It happens "often" (here and there) that new columns are added to database in any component and it isn't checked if those new columns require changes in 2 critical areas: backup and external functions.

So, with this new check... when it's detected (in the whole patch being analysed) that there are new columns being added @ any `install.xml` and `upgrade.php` file... and there isn't any change to backup (`/backup/moodle2`) or external (`externallib.php|/external/`) some warnings are added, with text:

```
- WARN: Database modifications (new tables or columns) detected in the patch without any change to some important areas.
- WARN: No changes detected to external functions, that may affect apps and other web service integrations, please verify!
- WARN: No changes detected to backup and restore, that may affect storage and transportability, please verify!
```

Note that they are only warnings because it perfectly could be that everything is ok and the new columns don't require any change to backup or to any external. But it's warned in order to remind to everybody that it must be checked.

The new check (`upgrade_external_backup_check.sh`) is completely covered with tests and also cibot (`remote_branch_checker`), that uses it, is.

Note that we cannot verify that CiBoT messages to the tracker are correct. It will be done as soon as this is lands. But it should work basically ok (only some small adjustment may be needed).

Ciao :-)