### PR TITLE
Pass the complete list of components to phpcs

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -498,10 +498,15 @@ echo "Info: Running phpcs..."
 if [[ ! -n "${phpcsstandard}" ]]; then
     phpcsstandard="${mydir}/../../codechecker/moodle"
 fi
+# Note we have to pass the full list of components (valid_components.txt) as calculated
+# earlier in the script when the whole code-base was available. Now, for performance
+# reasons, only the patch-modified files are remaining so we cannot use phpcs abilities
+# to detect all components anymore. Hence using the complete, already calculated, list.
 # Note we need to specify where both moodle and PHPCompatibility, specifically the later, standards sit.
 # TODO: Some day this will work from the moodle ruleset.xml file, it doesn't right now.
 ${phpcmd} ${mydir}/../vendor/bin/phpcs \
     --runtime-set installed_paths "${phpcsstandard}","${phpcsstandard}/../PHPCompatibility" \
+    --runtime-set moodleComponentsListPath "${WORKSPACE}/work/valid_components.txt" \
     --report=checkstyle --report-file="${WORKSPACE}/work/cs.xml" \
     --extensions=php --standard=${phpcsstandard} ${WORKSPACE}
 

--- a/tests/2-remote_branch_checker.bats
+++ b/tests/2-remote_branch_checker.bats
@@ -85,6 +85,10 @@ assert_prechecker () {
     assert_prechecker local_ci_fixture_upgrade_external_backup MDL-12345 c69c33b14d9fb83ca22bde558169e36b5e1047cf
 }
 
+@test "remote_branch_checker/remote_branch_checker.sh: phpcs aware of all components" {
+    assert_prechecker local_ci_fixture_phpcs_aware_components MDL-12345 c69c33b14d9fb83ca22bde558169e36b5e1047cf
+}
+
 @test "remote_branch_checker/remote_branch_checker.sh: bad amos script" {
     assert_prechecker fixture-bad-amos-commands MDL-12345 665c3ac59c35b7387a4fc70b8ac6600ce9ffeb87
 }

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_phpcs_aware_components.xml
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_phpcs_aware_components.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0"?>
+<smurf version="0.9.1" numerrors="2" numwarnings="1">
+  <summary status="error" numerrors="2" numwarnings="1" condensedresult="smurf,error,2,1:phplint,success,0,0;phpcs,error,2,1;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+    <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="phpcs" status="error" numerrors="2" numwarnings="1"/>
+    <detail name="js" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="css" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="phpdoc" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="commit" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
+  </summary>
+  <check id="phplint" title="PHP lint problems" url="http://php.net/docs.php" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows php lint problems in the code detected by php -l</description>
+    <mess/>
+  </check>
+  <check id="phpcs" title="PHP coding style problems" url="https://docs.moodle.org/dev/Coding_style" numerrors="2" numwarnings="1" allowfiltering="1">
+    <description>This section shows the coding style problems detected in the code by phpcs</description>
+    <mess>
+      <problem file="mod/glossary/tests/lib_test.php" linefrom="17" lineto="17" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/737b1bd19c9b979ec9d146f91c559c0fa7df5899/mod/glossary/tests/lib_test.php#L17" ruleset="moodle" rule="PHPUnit.TestCaseNames.UnexpectedNS" url="https://docs.moodle.org/dev/Coding_style" type="error" weight="5">
+        <message>PHPUnit class namespace "mod_wrong" does not match expected file namespace "mod_glossary"</message>
+        <description/>
+        <code/>
+      </problem>
+      <problem file="mod/glossary/tests/lib_test.php" linefrom="40" lineto="40" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/737b1bd19c9b979ec9d146f91c559c0fa7df5899/mod/glossary/tests/lib_test.php#L40" ruleset="moodle" rule="PHPUnit.TestCaseNames.NoMatch" url="https://docs.moodle.org/dev/Coding_style" type="warning" weight="1">
+        <message>PHPUnit testcase name "mod_glossary_lib_testcase_also_wrong" does not match file name "lib_test"</message>
+        <description/>
+        <code/>
+      </problem>
+      <problem file="mod/glossary/tests/lib_test.php" linefrom="40" lineto="40" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/737b1bd19c9b979ec9d146f91c559c0fa7df5899/mod/glossary/tests/lib_test.php#L40" ruleset="moodle" rule="PHPUnit.TestCaseNames.Irregular" url="https://docs.moodle.org/dev/Coding_style" type="error" weight="5">
+        <message>PHPUnit irregular testcase name found: mod_glossary_lib_testcase_also_wrong (_test/_testcase ended expected)</message>
+        <description/>
+        <code/>
+      </problem>
+    </mess>
+  </check>
+  <check id="js" title="Javascript coding style problems" url="https://docs.moodle.org/dev/Javascript/Coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the coding style problems detected in the code by eslint</description>
+    <mess/>
+  </check>
+  <check id="css" title="CSS problems" url="https://docs.moodle.org/dev/CSS_coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows CSS problems detected by stylelint</description>
+    <mess/>
+  </check>
+  <check id="phpdoc" title="PHPDocs style problems" url="https://docs.moodle.org/dev/Coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the phpdocs problems detected in the code by local_moodlecheck</description>
+    <mess/>
+  </check>
+  <check id="commit" title="Commit messages problems" url="https://docs.moodle.org/dev/Commit_cheat_sheet#Provide_clear_commit_messages" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the problems detected in the commit messages by the commits checker</description>
+    <mess/>
+  </check>
+  <check id="savepoint" title="Update savepoints problems" url="https://docs.moodle.org/dev/Upgrade_API" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows problems detected with the handling of upgrade savepoints</description>
+    <mess/>
+  </check>
+  <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="externalbackup" title="Missing changes in external functions or backup support for new detected tables or columns" url="https://docs.moodle.org/dev/Peer_reviewing#The_Moodle_mobile_app" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows potential problems detected when there are new database structures added in a patch and it is detected that nothing has been changed related with external functions (to be used by WS) or backup and restore. It must be checked that everything is correct and nothing is being missed in those areas.</description>
+    <mess/>
+  </check>
+  <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows files built by grunt and not commited</description>
+    <mess/>
+  </check>
+  <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows problems detected by shifter</description>
+    <mess/>
+  </check>
+  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section reports issues detected by Travis CI.</description>
+    <mess/>
+  </check>
+  <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows problems detected in mustache templates</description>
+    <mess/>
+  </check>
+  <check id="gherkin" title="Gherkin .feature problems" url="https://docs.moodle.org/dev/Writing_acceptance_tests" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows problems detected in behat .feature files</description>
+    <mess/>
+  </check>
+</smurf>


### PR DESCRIPTION
This is part of https://tracker.moodle.org/browse/MDL-71049
(last step towards having all the machinery working for CiBoT)

Normally, phpcs itself is able to get all the components
installed in a given dir root (it just loads them using
standard core_component class).

But, for performance reasons, with CiBoT, we delete all
files from dir root but those being part of the patchest
being analysed (and a few exceptions like version.php, grunt...).

That means that it's unable to load core_component or find all
the components available in a site.

But that's ok, because one of the first things that the remote
branch checker already does (before deleting files), is to, always,
calculate all the valid components and save them to the
/work/valid_components.txt file.

And then, codechecker can use the new config setting
"moodleComponentsListPath" to load exactly that file. See
https://github.com/moodlehq/moodle-local_codechecker/pull/160
for more information about that feature.

Covered with tests to verify that it's getting the components
information properly.