### PR TITLE
Remove the travis checker from CiBoT

### DIFF
--- a/remote_branch_checker/checkstyle_converter.php
+++ b/remote_branch_checker/checkstyle_converter.php
@@ -41,7 +41,7 @@ if ($unrecognized) {
 
 }
 
-$validformats = array('phplint', 'thirdparty', 'gruntdiff', 'shifter', 'travis', 'mustachelint', 'gherkinlint');
+$validformats = array('phplint', 'thirdparty', 'gruntdiff', 'shifter', 'mustachelint', 'gherkinlint');
 
 
     $help =
@@ -209,35 +209,6 @@ function process_shifter($line) {
         $output.= '<file name="' . $filename. '">'.PHP_EOL;
         $output.= '<error line="'.$lineno.'" column="0" severity="error" ';
         $output.= 'message="' .s($message). ' "/>' . PHP_EOL;
-        $output.= '</file>';
-    }
-
-    return $output;
-}
-
-/**
- * Converts travis branch checker output into checkstyle format
- *
- * Example input:
- *   ERROR: Travis build failed, see https://travis-ci.org/username/moodle/builds/108712908
- *
- * @param string $line the line of file
- * @return string the xml fragment
- */
-function process_travis($line) {
-    $output = '';
-    if (preg_match('/^(ERROR|WARNING): (.*)$/', $line, $matches)) {
-        $severity = strtolower($matches[1]);
-        $message= $matches[2];
-
-        $diffurl = '';
-        if (preg_match('#(https://\S+)#', $message, $urlmatches)) {
-            $diffurl = $urlmatches[1];
-        }
-
-        $output.= '<file name="">'.PHP_EOL;
-        $output.= '<error diffurl="'.$diffurl.'" line="0" column="0" severity="'.$severity.'" ';
-        $output.= 'message="'.$message.'"/>' . PHP_EOL;
         $output.= '</file>';
     }
 

--- a/remote_branch_checker/lib.php
+++ b/remote_branch_checker/lib.php
@@ -276,23 +276,6 @@ class remote_branch_reporter {
             }
         }
 
-        // Process the travis output, weighting errors with 5 and warnings with 1
-        $params = array(
-            'title' => 'Travis CI problems',
-            'abbr' => 'travis',
-            'description' => 'This section reports issues detected by Travis CI.',
-            'url' => 'https://docs.moodle.org/dev/Travis_Integration',
-            'codedir' => dirname($this->directory) . '/',
-            'errorweight' => 5,
-            'warningweight' => 1,
-            'allowfiltering' => 1);
-        if ($node = $this->apply_xslt($params, $this->directory . '/travis.xml', 'checkstyle2smurf.xsl')) {
-            if ($check = $node->getElementsByTagName('check')->item(0)) {
-                $snode = $doc->importNode($check, true);
-                $smurf->appendChild($snode);
-            }
-        }
-
         // Process the mustache output, weighting errors with 5 and warnings with 1
         $params = array(
             'title' => 'Mustache template problems',
@@ -514,7 +497,7 @@ class remote_branch_reporter {
             $xpath = new DOMXPath($doc);
 
             // Populate all the normal problems with git diff urls.
-            $problems = $xpath->query('//check[not(contains(@id, "commit") or contains(@id, "travis"))]//problem');
+            $problems = $xpath->query('//check[not(contains(@id, "commit"))]//problem');
             foreach ($problems as $problem) {
                 if ($problem->hasAttribute('file') && $problem->hasAttribute('linefrom')) {
                     // Is an actual file diff..

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -389,12 +389,8 @@ if [ -f ${WORKSPACE}/Gruntfile.js ]; then
     cat "${WORKSPACE}/work/grunt-errors.txt" | ${phpcmd} ${mydir}/checkstyle_converter.php --format=shifter > "${WORKSPACE}/work/shifter.xml"
 fi
 
-if [[ -z "${isplugin}" ]]; then
-    echo "Info: Running travis..."
-    ${phpcmd} ${mydir}/../travis/check_branch_status.php --repository="$remote" --branch="$branch" > "${WORKSPACE}/work/travis.txt"
-    cat "${WORKSPACE}/work/travis.txt" | ${phpcmd} ${mydir}/checkstyle_converter.php --format=travis > "${WORKSPACE}/work/travis.xml"
-fi
-
+# TODO: Maybe add a GHA checker to see if the user has them enabled? 99% of times they will, but can be checked with just
+# a quick http request (without looking to more details using the API.
 
 # ########## ########## ########## ##########
 

--- a/tests/1-checkstyle_manipulations.bats
+++ b/tests/1-checkstyle_manipulations.bats
@@ -49,11 +49,6 @@ assert_checkstyle() {
     assert_checkstyle 'remote_branch_checker/checkstyle_converter.php --format=shifter' grunt-errors.txt shifter.xml
 }
 
-@test "remote_branch_checker/checkstyle_converter.php: travis" {
-    assert_checkstyle 'remote_branch_checker/checkstyle_converter.php --format=travis' travis.txt travis.xml
-    assert_checkstyle 'remote_branch_checker/checkstyle_converter.php --format=travis' travis-error.txt travis-error.xml
-}
-
 @test "remote_branch_checker/checkstyle_converter.php: mustachelint" {
     assert_checkstyle 'remote_branch_checker/checkstyle_converter.php --format=mustachelint' mustachelint.txt mustachelint.xml
 }

--- a/tests/fixtures/checkstyle/travis-error.txt
+++ b/tests/fixtures/checkstyle/travis-error.txt
@@ -1,1 +1,0 @@
-ERROR: Build failed, see https://travis-ci.org/zanekarl17/moodle/builds/141726911

--- a/tests/fixtures/checkstyle/travis-error.xml
+++ b/tests/fixtures/checkstyle/travis-error.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="1.3.2">
-<file name="">
-<error diffurl="https://travis-ci.org/zanekarl17/moodle/builds/141726911" line="0" column="0" severity="error" message="Build failed, see https://travis-ci.org/zanekarl17/moodle/builds/141726911"/>
-</file></checkstyle>

--- a/tests/fixtures/checkstyle/travis.txt
+++ b/tests/fixtures/checkstyle/travis.txt
@@ -1,1 +1,0 @@
-WARNING: Travis integration not setup. See https://docs.moodle.org/dev/Travis_Integration

--- a/tests/fixtures/checkstyle/travis.xml
+++ b/tests/fixtures/checkstyle/travis.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="1.3.2">
-<file name="">
-<error diffurl="https://docs.moodle.org/dev/Travis_Integration" line="0" column="0" severity="warning" message="Travis integration not setup. See https://docs.moodle.org/dev/Travis_Integration"/>
-</file></checkstyle>

--- a/tests/fixtures/remote_branch_checker/MDL-53572-master-8ce58c9.xml
+++ b/tests/fixtures/remote_branch_checker/MDL-53572-master-8ce58c9.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="0" numwarnings="0">
-  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
     <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
   </summary>
@@ -58,10 +57,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-bad-amos-commands.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-bad-amos-commands.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="2" numwarnings="0">
-  <summary status="error" numerrors="2" numwarnings="0" condensedresult="smurf,error,2,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,error,2,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="error" numerrors="2" numwarnings="0" condensedresult="smurf,error,2,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,error,2,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
     <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
   </summary>
@@ -74,10 +73,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-gherkin-lint.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-gherkin-lint.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="4" numwarnings="1">
-  <summary status="error" numerrors="4" numwarnings="1" condensedresult="smurf,error,4,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,error,3,0">
+  <summary status="error" numerrors="4" numwarnings="1" condensedresult="smurf,error,4,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;mustache,success,0,0;gherkin,error,3,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="error" numerrors="1" numwarnings="1"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
     <detail name="gherkin" status="error" numerrors="3" numwarnings="0"/>
   </summary>
@@ -69,10 +68,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-good-amos-commit.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-good-amos-commit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="0" numwarnings="0">
-  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
     <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
   </summary>
@@ -64,10 +63,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-grunt-build-failed.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-grunt-build-failed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="3" numwarnings="1">
-  <summary status="error" numerrors="3" numwarnings="1" condensedresult="smurf,error,3,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,2,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="error" numerrors="3" numwarnings="1" condensedresult="smurf,error,3,1:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,2,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="error" numerrors="1" numwarnings="1"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
     <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
   </summary>
@@ -80,10 +79,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-mustache-lint-js.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-mustache-lint-js.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="0" numwarnings="2">
-  <summary status="warning" numerrors="0" numwarnings="2" condensedresult="smurf,warning,0,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,warning,0,2;gherkin,success,0,0">
+  <summary status="warning" numerrors="0" numwarnings="2" condensedresult="smurf,warning,0,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;mustache,warning,0,2;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="warning" numerrors="0" numwarnings="2"/>
     <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
   </summary>
@@ -58,10 +57,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="2" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-mustache-lint.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-mustache-lint.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="1" numwarnings="4">
-  <summary status="error" numerrors="1" numwarnings="4" condensedresult="smurf,error,1,4:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,error,1,4;gherkin,success,0,0">
+  <summary status="error" numerrors="1" numwarnings="4" condensedresult="smurf,error,1,4:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;mustache,error,1,4;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="error" numerrors="1" numwarnings="4"/>
     <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
   </summary>
@@ -58,10 +57,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="1" numwarnings="4" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-non-code-update.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-non-code-update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="0" numwarnings="0">
-  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
     <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
   </summary>
@@ -58,10 +57,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/fixture-thirdparty-css.xml
+++ b/tests/fixtures/remote_branch_checker/fixture-thirdparty-css.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="0" numwarnings="2">
-  <summary status="warning" numerrors="0" numwarnings="2" condensedresult="smurf,warning,0,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,warning,0,2;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="warning" numerrors="0" numwarnings="2" condensedresult="smurf,warning,0,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,warning,0,2;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
     <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
   </summary>
@@ -69,10 +68,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_manyproblems.xml
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_manyproblems.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="11" numwarnings="6">
-  <summary status="error" numerrors="11" numwarnings="6" condensedresult="smurf,error,11,6:phplint,error,1,0;phpcs,error,2,2;js,error,1,1;css,error,3,0;phpdoc,success,0,0;commit,error,1,1;savepoint,error,2,0;thirdparty,warning,0,1;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="error" numerrors="11" numwarnings="6" condensedresult="smurf,error,11,6:phplint,error,1,0;phpcs,error,2,2;js,error,1,1;css,error,3,0;phpdoc,success,0,0;commit,error,1,1;savepoint,error,2,0;thirdparty,warning,0,1;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="error" numerrors="1" numwarnings="0"/>
     <detail name="phpcs" status="error" numerrors="2" numwarnings="2"/>
     <detail name="js" status="error" numerrors="1" numwarnings="1"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="error" numerrors="1" numwarnings="1"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
     <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
   </summary>
@@ -151,10 +150,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_oldbranch.xml
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_oldbranch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="4" numwarnings="7">
-  <summary status="error" numerrors="4" numwarnings="7" condensedresult="smurf,error,4,7:phplint,success,0,0;phpcs,success,0,0;js,warning,0,6;css,success,0,0;phpdoc,success,0,0;commit,error,3,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0">
+  <summary status="error" numerrors="4" numwarnings="7" condensedresult="smurf,error,4,7:phplint,success,0,0;phpcs,success,0,0;js,warning,0,6;css,success,0,0;phpdoc,success,0,0;commit,error,3,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;mustache,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="warning" numerrors="0" numwarnings="6"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="error" numerrors="1" numwarnings="1"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
   </summary>
   <check id="phplint" title="PHP lint problems" url="http://php.net/docs.php" numerrors="0" numwarnings="0" allowfiltering="0">
@@ -115,10 +114,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_phpcs_aware_components.xml
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_phpcs_aware_components.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="2" numwarnings="1">
-  <summary status="error" numerrors="2" numwarnings="1" condensedresult="smurf,error,2,1:phplint,success,0,0;phpcs,error,2,1;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="error" numerrors="2" numwarnings="1" condensedresult="smurf,error,2,1:phplint,success,0,0;phpcs,error,2,1;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,success,0,0;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="error" numerrors="2" numwarnings="1"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
     <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
   </summary>
@@ -74,10 +73,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_external_backup.xml
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_external_backup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="0" numwarnings="3">
-  <summary status="warning" numerrors="0" numwarnings="3" condensedresult="smurf,warning,0,3:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,warning,0,3;grunt,success,0,0;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="warning" numerrors="0" numwarnings="3" condensedresult="smurf,warning,0,3:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,warning,0,3;grunt,success,0,0;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="warning" numerrors="0" numwarnings="3"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
     <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
   </summary>
@@ -74,10 +73,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_checker/prechecker-fixture-stylelint.xml
+++ b/tests/fixtures/remote_branch_checker/prechecker-fixture-stylelint.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="5" numwarnings="2">
-  <summary status="error" numerrors="5" numwarnings="2" condensedresult="smurf,error,5,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,4,1;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;travis,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+  <summary status="error" numerrors="5" numwarnings="2" condensedresult="smurf,error,5,2:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,error,4,1;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;externalbackup,success,0,0;grunt,error,1,1;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -12,7 +12,6 @@
     <detail name="externalbackup" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="error" numerrors="1" numwarnings="1"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
     <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
     <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
   </summary>
@@ -95,10 +94,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
   <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">

--- a/tests/fixtures/remote_branch_reporter/MDL-54987/smurf.html
+++ b/tests/fixtures/remote_branch_reporter/MDL-54987/smurf.html
@@ -10,7 +10,7 @@
     </style></head><body><header><h1 id="top">
         Prechecker results:
         <span class="text-error">error</span></h1></header><nav><span class="total-counts text-error">
-        (55 errors/6 warnings)
+        (54 errors/6 warnings)
         =&gt;
       </span><a class="text-success" href="#phplint">phplint
           (0/0),
@@ -32,8 +32,6 @@
           (3/0),
         </a><a class="text-success" href="#shifter">shifter
           (0/0),
-        </a><a class="text-error" href="#travis">travis
-          (1/0),
         </a></nav><hr/><main><article><h2 id="phplint">PHP lint problems<a href="#top"><span class="icon icon-chevron-up"/></a></h2><p>(0 errors, 0 warnings)</p><p>This section shows php lint problems in the code detected by php -l<a href="http://php.net/docs.php">
               [More info]
             </a></p><dl/></article><hr/><article><h2 id="phpcs">PHP coding style problems<a href="#top"><span class="icon icon-chevron-up"/></a></h2><p>(20 errors, 2 warnings)</p><p>This section shows the coding style problems detected in the code by phpcs<a href="https://docs.moodle.org/dev/Coding_style">
@@ -82,6 +80,4 @@
               [More info]
             </a></p><dl><dt>lib/amd/build/chart_base.min.js</dt><dd><a class="text-error" href="https://github.com/FMCorz/moodle/blob/1869439cb1a12d82ea5bfc22a49527299f9c9620/lib/amd/build/chart_base.min.js#L0">Uncommitted change detected.</a></dd><dt>lib/amd/build/chart_output_htmltable.min.js</dt><dd><a class="text-error" href="https://github.com/FMCorz/moodle/blob/1869439cb1a12d82ea5bfc22a49527299f9c9620/lib/amd/build/chart_output_htmltable.min.js#L0">Uncommitted change detected.</a></dd><dt>lib/amd/build/chartjs-lazy.min.js</dt><dd><a class="text-error" href="https://github.com/FMCorz/moodle/blob/1869439cb1a12d82ea5bfc22a49527299f9c9620/lib/amd/build/chartjs-lazy.min.js#L0">Uncommitted change detected.</a></dd></dl></article><hr/><article><h2 id="shifter">shifter problems<a href="#top"><span class="icon icon-chevron-up"/></a></h2><p>(0 errors, 0 warnings)</p><p>This section shows problems detected by shifter<a href="https://docs.moodle.org/dev/YUI/Shifter">
               [More info]
-            </a></p><dl/></article><hr/><article><h2 id="travis">Travis CI problems<a href="#top"><span class="icon icon-chevron-up"/></a></h2><p>(1 errors, 0 warnings)</p><p>This section reports issues detected by Travis CI.<a href="https://docs.moodle.org/dev/Travis_Integration">
-              [More info]
-            </a></p><dl><dt/><dd><a class="text-error" href="https://travis-ci.org/FMCorz/moodle/builds/146598004">Build failed, see https://travis-ci.org/FMCorz/moodle/builds/146598004</a></dd></dl></article><hr/></main></body></html>
+            </a></p><dl/></article><hr/></main></body></html>

--- a/tests/fixtures/remote_branch_reporter/MDL-54987/smurf.xml
+++ b/tests/fixtures/remote_branch_reporter/MDL-54987/smurf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<smurf version="0.9.1" numerrors="55" numwarnings="6">
-  <summary status="error" numerrors="55" numwarnings="6" condensedresult="smurf,error,55,6:phplint,success,0,0;phpcs,error,20,2;js,warning,0,3;css,success,0,0;phpdoc,error,3,0;commit,error,28,1;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,3,0;shifter,success,0,0;travis,error,1,0">
+<smurf version="0.9.1" numerrors="54" numwarnings="6">
+  <summary status="error" numerrors="54" numwarnings="6" condensedresult="smurf,error,54,6:phplint,success,0,0;phpcs,error,20,2;js,warning,0,3;css,success,0,0;phpdoc,error,3,0;commit,error,28,1;savepoint,success,0,0;thirdparty,success,0,0;grunt,error,3,0;shifter,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="error" numerrors="20" numwarnings="2"/>
     <detail name="js" status="warning" numerrors="0" numwarnings="3"/>
@@ -11,7 +11,6 @@
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="error" numerrors="3" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="error" numerrors="1" numwarnings="0"/>
   </summary>
   <check id="phplint" title="PHP lint problems" url="http://php.net/docs.php" numerrors="0" numwarnings="0" allowfiltering="0">
     <description>This section shows php lint problems in the code detected by php -l</description>
@@ -357,15 +356,5 @@
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
     <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="1" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
-    <mess>
-      <problem file="" linefrom="0" lineto="0" method="" class="" package="" api="" diffurl="https://travis-ci.org/FMCorz/moodle/builds/146598004" ruleset="moodle" rule="" url="https://docs.moodle.org/dev/Travis_Integration" type="error" weight="5">
-        <message>Build failed, see https://travis-ci.org/FMCorz/moodle/builds/146598004</message>
-        <description/>
-        <code/>
-      </problem>
-    </mess>
   </check>
 </smurf>

--- a/tests/fixtures/remote_branch_reporter/MDL-54987/travis.xml
+++ b/tests/fixtures/remote_branch_reporter/MDL-54987/travis.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="1.3.2">
-<file name="">
-<error diffurl="https://travis-ci.org/FMCorz/moodle/builds/146598004" line="0" column="0" severity="error" message="Build failed, see https://travis-ci.org/FMCorz/moodle/builds/146598004"/>
-</file></checkstyle>

--- a/tests/fixtures/remote_branch_reporter/MDL-55322/smurf.html
+++ b/tests/fixtures/remote_branch_reporter/MDL-55322/smurf.html
@@ -32,8 +32,6 @@
           (0/0),
         </a><a class="text-success" href="#shifter">shifter
           (0/0),
-        </a><a class="text-success" href="#travis">travis
-          (0/0),
         </a></nav><hr/><main><article><h2 id="phplint">PHP lint problems<a href="#top"><span class="icon icon-chevron-up"/></a></h2><p>(0 errors, 0 warnings)</p><p>This section shows php lint problems in the code detected by php -l<a href="http://php.net/docs.php">
               [More info]
             </a></p><dl/></article><hr/><article><h2 id="phpcs">PHP coding style problems<a href="#top"><span class="icon icon-chevron-up"/></a></h2><p>(0 errors, 0 warnings)</p><p>This section shows the coding style problems detected in the code by phpcs<a href="https://docs.moodle.org/dev/Coding_style">
@@ -53,7 +51,5 @@
             </a></p><dl/></article><hr/><article><h2 id="grunt">grunt changes<a href="#top"><span class="icon icon-chevron-up"/></a></h2><p>(0 errors, 0 warnings)</p><p>This section shows files built by grunt and not commited<a href="https://docs.moodle.org/dev/Grunt">
               [More info]
             </a></p><dl/></article><hr/><article><h2 id="shifter">shifter problems<a href="#top"><span class="icon icon-chevron-up"/></a></h2><p>(0 errors, 0 warnings)</p><p>This section shows problems detected by shifter<a href="https://docs.moodle.org/dev/YUI/Shifter">
-              [More info]
-            </a></p><dl/></article><hr/><article><h2 id="travis">Travis CI problems<a href="#top"><span class="icon icon-chevron-up"/></a></h2><p>(0 errors, 0 warnings)</p><p>This section reports issues detected by Travis CI.<a href="https://docs.moodle.org/dev/Travis_Integration">
               [More info]
             </a></p><dl/></article><hr/></main></body></html>

--- a/tests/fixtures/remote_branch_reporter/MDL-55322/smurf.xml
+++ b/tests/fixtures/remote_branch_reporter/MDL-55322/smurf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <smurf version="0.9.1" numerrors="0" numwarnings="0">
-  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;travis,success,0,0">
+  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;commit,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0">
     <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
     <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
     <detail name="js" status="success" numerrors="0" numwarnings="0"/>
@@ -11,7 +11,6 @@
     <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
     <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
     <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
-    <detail name="travis" status="success" numerrors="0" numwarnings="0"/>
   </summary>
   <check id="phplint" title="PHP lint problems" url="http://php.net/docs.php" numerrors="0" numwarnings="0" allowfiltering="0">
     <description>This section shows php lint problems in the code detected by php -l</description>
@@ -51,10 +50,6 @@
   </check>
   <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
     <description>This section shows problems detected by shifter</description>
-    <mess/>
-  </check>
-  <check id="travis" title="Travis CI problems" url="https://docs.moodle.org/dev/Travis_Integration" numerrors="0" numwarnings="0" allowfiltering="1">
-    <description>This section reports issues detected by Travis CI.</description>
     <mess/>
   </check>
 </smurf>

--- a/tests/fixtures/remote_branch_reporter/MDL-55322/travis.xml
+++ b/tests/fixtures/remote_branch_reporter/MDL-55322/travis.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="1.3.2">
-</checkstyle>


### PR DESCRIPTION
With everything and everybody already moved to GHA, it
doesn't make much sense to keep the travis checker running
on every CiBoT execution.

Hence, removing it from CiBoT (remote_branch_checker) and
associated tests. But keeping the shell script and its own
tests, in case they are useful for anybody.

Also, added TODO about the possibility of adding a GHA
checker (a simple https request can tell us if actions are
enabled for a repo), but not sure if it's worth it as far
as 99% of people have them enabled.