### PR TITLE
Move to moodle cs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ integration happens.
 + Some checks require a MySQL, master-based site to be up and running.
 + Some checks require a PHP engine to run (other are pure shell scripts).
 + Some checks require the installation of 3rd part tools (phpunit...).
-+ Some checks require the presence of both local_codechecker and local_moodlecheck local plugins.
++ Some checks require the presence of local_moodlecheck local plugin.
++ To get all other dependencies installed, ensure that both composer and npm are run regularly.
 + You can run them standalone or also with the ease and functionalities coming with different tools like:
     - Jenkins: http://jenkins-php.org
     - Travis: https://docs.travis-ci.com/user/languages/php/

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,11 @@
 {
     "require": {
-        "squizlabs/php_codesniffer": "^3.5.8",
-        "mustache/mustache": "^2.11"
+        "moodlehq/moodle-cs": "^3.2.3",
+        "mustache/mustache": "^2.14.1"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/initial_jenkins_moodle_setup/initial_jenkins_moodle_setup.sh
+++ b/initial_jenkins_moodle_setup/initial_jenkins_moodle_setup.sh
@@ -84,15 +84,6 @@ else
 fi
 cd ${basedir}/${gitdir}/${moodledir} && ${gitcmd} pull origin master && ${gitcmd} reset --hard v2.4.0-beta
 
-# Create the git clone for the codechecker, master branch and add it to .git/info/exclude
-if [ -d "${basedir}/${gitdir}/${moodledir}/local/codechecker" ]; then
-    echo "Skip https://github.com/moodlehq/moodle-local_codechecker.git already present at local/codechecker"
-else
-    cd ${basedir}/${gitdir}/${moodledir}/local && ${gitcmd} clone https://github.com/moodlehq/moodle-local_codechecker.git codechecker
-    echo local/codechecker >> ${basedir}/${gitdir}/${moodledir}/.git/info/exclude
-fi
-cd ${basedir}/${gitdir}/${moodledir}/local/codechecker && ${gitcmd} pull origin master && ${gitcmd} reset --hard origin/master
-
 # Create the git clone for the moodlecheck, master branch and add it to .git/info/exclude
 if [ -d "${basedir}/${gitdir}/${moodledir}/local/moodlecheck" ]; then
     echo "Skip https://github.com/moodlehq/moodle-local_moodlecheck.git already present at local/moodlecheck"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,25 @@
 {
   "name": "moodle-local_ci",
   "version": "0.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "moodle-local_ci",
+      "version": "0.0.1",
+      "dependencies": {
+        "vnu-jar": "18.11.5"
+      }
+    },
+    "node_modules/vnu-jar": {
+      "version": "18.11.5",
+      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-18.11.5.tgz",
+      "integrity": "sha512-XxTYLOUgQYdvIlAgX1BtxZiQ97/OKuBaEojqZdjMnjI+OXDkSyQGNGpzUQIQygeRrFVdQ1/eAVfiRE/iIlV0fg==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    }
+  },
   "dependencies": {
     "vnu-jar": {
       "version": "18.11.5",

--- a/run_phpunittests/run_phpunittests.sh
+++ b/run_phpunittests/run_phpunittests.sh
@@ -112,7 +112,7 @@ definedtests=$(grep -r "directory suffix" ${gitdir}/phpunit.xml | sed 's/^[^>]*>
 # Load all the existing tests
 existingtests=$(cd ${gitdir} && find . -name tests | sed 's/^\.\/\(.*\)$/\1/g')
 # Some well-known "tests" that we can ignore here
-ignoretests="local/codechecker/pear/PHP/tests lib/phpexcel/PHPExcel/Shared/JAMA/tests"
+ignoretests="lib/phpexcel/PHPExcel/Shared/JAMA/tests"
 # Unit test classes to look for with each file (must be 1 and only 1). MDLSITE-2096
 # TODO: Some day replace this with the list of abstract classes, from PHPUnit_Framework_TestCase using some classmap
 unittestclasses="basic_testcase advanced_testcase database_driver_testcase externallib_advanced_testcase data_loading_method_test_base question_testcase question_attempt_upgrader_test_base qbehaviour_walkthrough_test_base grade_base_testcase"

--- a/version.php
+++ b/version.php
@@ -27,8 +27,7 @@ defined('MOODLE_INTERNAL') || die;
 $plugin->version   = 2012113000;
 $plugin->requires  = 2013070400;        // Moodle 2.6dev (Build 20130704) and upwards.
 $plugin->dependencies = array(          // Also requires these plugins to be installed.
-    'local_codechecker' => '2012061600',
-    'local_moodlecheck' => '2012011000'
+    'local_moodlecheck' => '2012011000',
 );
 $plugin->component = 'local_ci';
 $plugin->release   = '0.9.1';

--- a/versions_check_set/versions_check_set.sh
+++ b/versions_check_set/versions_check_set.sh
@@ -79,7 +79,7 @@ ${mydir}/../list_valid_components/list_valid_components.sh > "${WORKSPACE}/valid
 allfiles=$( find "${gitdir}" -name version.php | awk -F "/" '{print NF-1"\t"$0}' | sort -n | cut -f 2- )
 
 # version.php files to ignore
-ignorefiles="(local/(ci|codechecker|moodlecheck)/version.php|.*/tests/fixtures/.*/version.php)"
+ignorefiles="(local/(ci|moodlecheck)/version.php|.*/tests/fixtures/.*/version.php)"
 
 # Perform various checks with the version.php files
 for i in ${allfiles}; do


### PR DESCRIPTION
A couple of commits to completely move from local_codechecker to moodle-cs

1. [Remove any mention / use of local_moodlechecker](https://github.com/moodlehq/moodle-local_ci/commit/c1913ef4470b8cc5bc197f1a8a965efd0a195ad7)  …
This isn't going to be any more a dependency of local_ci
because it's being replaced by upstream PHP_CodeSniffer
using the moodle-cs standard installed.

2. [Switch to composer-installed phpcs and moodle-cs](https://github.com/moodlehq/moodle-local_ci/commit/6baac903b7631226d2c4e2c2781012978e182e0e)  …
Not much to say, just install moodle-cs with composer
and ensure that CiBoT is using the phpcs that comes with it.

Let's see how tests go (everything should remain passing 🤞 ).

Ciao :-)