### PR TITLE
Verify phpunit xml

### DIFF
--- a/phplib/clilib.php
+++ b/phplib/clilib.php
@@ -234,6 +234,7 @@ function load_core_component_from_moodle($moodledirroot) {
     $CFG->dirroot = $moodledirroot;
     $CFG->libdir = $CFG->dirroot . '/lib';
     $CFG->admin = 'admin';
+    $CFG->filepermissions = '0666';
     require_once($CFG->dirroot . '/lib/classes/component.php');
 
     return true;

--- a/tests/1-verify_phpunit_xml.bats
+++ b/tests/1-verify_phpunit_xml.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+load libs/shared_setup
+
+setup () {
+    create_git_branch MOODLE_311_STABLE v3.11.7
+    # Restore workspace if not first test.
+    first_test || restore_workspace
+}
+
+teardown () {
+    # Store workspace if not last test.
+    last_test || store_workspace
+}
+
+@test "verify_phpunit_xml: normal run without errors" {
+    ci_run verify_phpunit_xml/verify_phpunit_xml.sh
+
+    assert_success
+    assert_output --partial "OK: competency/tests will be executed"
+    assert_output --partial "INFO: backup/util/ui/tests will be executed because the backup/util definition"
+    assert_output --partial "INFO: Ignoring admin/tests, it does not contain any test unit file."
+    assert_output --partial "WARNING: message/tests/api_test.php has incorrect (0) number of unit test classes."
+    refute_output --partial "ERROR"
+}
+
+@test "verify_phpunit_xml: test detected into not covered by suite directory" {
+    git_apply_fixture verify_phpunit_xml/add_uncovered_test.patch
+
+    ci_run verify_phpunit_xml/verify_phpunit_xml.sh
+
+    assert_failure
+    assert_output --partial "OK: competency/tests will be executed"
+    assert_output --partial "INFO: backup/util/ui/tests will be executed because the backup/util definition"
+    assert_output --partial "ERROR: admin/tests is not matched/covered by any definition in phpunit.xml !"
+    assert_output --partial "WARNING: message/tests/api_test.php has incorrect (0) number of unit test classes."
+    assert_output --partial "ERROR"
+}
+
+@test "verify_phpunit_xml: multiple classes in unit test file are warned by default" {
+    git_apply_fixture verify_phpunit_xml/multiple_classes_in_file.patch
+
+    ci_run verify_phpunit_xml/verify_phpunit_xml.sh
+
+    assert_success
+    assert_output --partial "OK: competency/tests will be executed"
+    assert_output --partial "INFO: backup/util/ui/tests will be executed because the backup/util definition"
+    assert_output --partial "INFO: Ignoring admin/tests, it does not contain any test unit file."
+    assert_output --partial "WARNING: mod/glossary/tests/lib_test.php has incorrect (2) number of unit test classes."
+    refute_output --partial "ERROR"
+}
+
+@test "verify_phpunit_xml: multiple classes in unit test file emit error if configured" {
+    git_apply_fixture verify_phpunit_xml/multiple_classes_in_file.patch
+
+    export multipleclassiserror=yes # Let's force multiple classes to lead to error.
+
+    ci_run verify_phpunit_xml/verify_phpunit_xml.sh
+
+    assert_failure
+    assert_output --partial "OK: competency/tests will be executed"
+    assert_output --partial "INFO: backup/util/ui/tests will be executed because the backup/util definition"
+    assert_output --partial "INFO: Ignoring admin/tests, it does not contain any test unit file."
+    assert_output --partial "ERROR: mod/glossary/tests/lib_test.php has incorrect (2) number of unit test classes."
+    assert_output --partial "ERROR"
+}

--- a/tests/fixtures/verify_phpunit_xml/add_uncovered_test.patch
+++ b/tests/fixtures/verify_phpunit_xml/add_uncovered_test.patch
@@ -1,0 +1,25 @@
+From e769cd9f4260e534244b93c8fb70bd7ad1c17707 Mon Sep 17 00:00:00 2001
+From: "Eloy Lafuente (stronk7)" <stronk7@moodle.org>
+Date: Tue, 7 Jun 2022 16:29:15 +0200
+Subject: [PATCH] Add a test into admin/tests
+
+---
+ admin/tests/some_test.php | 6 ++++++
+ 1 file changed, 6 insertions(+)
+ create mode 100644 admin/tests/some_test.php
+
+diff --git a/admin/tests/some_test.php b/admin/tests/some_test.php
+new file mode 100644
+index 0000000000..25ec9d94b0
+--- /dev/null
++++ b/admin/tests/some_test.php
+@@ -0,0 +1,6 @@
++<?php
++
++class some_test extends \advanced_testcase {
++    public function test_something() {
++    }
++}
+-- 
+2.36.1
+

--- a/tests/fixtures/verify_phpunit_xml/multiple_classes_in_file.patch
+++ b/tests/fixtures/verify_phpunit_xml/multiple_classes_in_file.patch
@@ -1,0 +1,26 @@
+From c8985b50116b5d27018f428b7e0f2e0678096efa Mon Sep 17 00:00:00 2001
+From: "Eloy Lafuente (stronk7)" <stronk7@moodle.org>
+Date: Tue, 7 Jun 2022 18:09:41 +0200
+Subject: [PATCH] Using more than one unit test class in a file is detected
+
+---
+ mod/glossary/tests/lib_test.php | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/mod/glossary/tests/lib_test.php b/mod/glossary/tests/lib_test.php
+index 9d78bed6c3..fb4df1206a 100644
+--- a/mod/glossary/tests/lib_test.php
++++ b/mod/glossary/tests/lib_test.php
+@@ -29,6 +29,9 @@ global $CFG;
+ require_once($CFG->dirroot . '/mod/glossary/lib.php');
+ require_once($CFG->dirroot . '/mod/glossary/locallib.php');
+ 
++class another_test extends \advanced_testcase {
++}
++
+ /**
+  * Glossary lib testcase.
+  *
+-- 
+2.36.1
+

--- a/verify_phpunit_xml/create_phpunit_xml.php
+++ b/verify_phpunit_xml/create_phpunit_xml.php
@@ -1,0 +1,91 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * CLI utility in charge of creating the main phpunit.xml file for further inspections.
+ *
+ * For a given, valid, Moodle's root directory (dirroot), this will generate
+ * the phpunit.xml, normally used by phpunit runs. The main difference is that it's
+ * done in a way a real site and database are not needed, so it's quicker and easier
+ * to run in any environment (very similar to list_valid_components job).
+ *
+ * @category   test
+ * @package    local_ci
+ * @subpackage remote_branch_checker
+ * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__.'/../phplib/clilib.php');
+
+// now get cli options
+list($options, $unrecognized) = cli_get_params(
+    [
+        'help'   => false,
+        'basedir' => '',
+    ],
+    [
+        'h' => 'help',
+        'b' => 'basedir',
+    ]
+);
+
+if ($unrecognized) {
+    $unrecognized = implode("\n  ", $unrecognized);
+    cli_error("Unrecognised options:\n{$unrecognized}\n Please use --help option.");
+}
+
+if ($options['help']) {
+    $help =
+"Generate the phpunit.xml file for a given Moodle's root directory.
+
+Options:
+-h, --help            Print out this help.
+--basedir             Full path to the moodle base dir to look for components.
+
+Example:
+php local/ci/verify_phpunit_xml/create_phpunit_xml.php --basedir=/home/moodle/git
+";
+
+    echo $help;
+    exit(0);
+}
+
+if (empty($options['basedir'])) {
+    cli_error('Missing basedir param. Please use --help option.');
+}
+if (!file_exists($options['basedir'])) {
+    cli_error('Incorrect directory: ' . $options['basedir']);
+}
+if (!is_writable($options['basedir'])) {
+    cli_error('Non-writable directory: ' . $options['basedir']);
+}
+
+// We need all the components loaded first.
+if (!load_core_component_from_moodle($options['basedir'])) {
+    cli_error('Something went wrong. Components not loaded from ' . $options['basedir']);
+}
+
+// Now, let's invoke phpunit utils to generate the phpunit.xml file
+
+// We need to load a few stuff.
+require_once($options['basedir'] . '/lib/phpunit/classes/util.php');
+require_once($options['basedir'] . '/lib/outputcomponents.php');
+require_once($options['basedir'] . '/lib/testing/lib.php');
+phpunit_util::build_config_file();
+
+// We are done, end here.
+exit(0);

--- a/verify_phpunit_xml/verify_phpunit_xml.sh
+++ b/verify_phpunit_xml/verify_phpunit_xml.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# $phpcmd: Path to the PHP CLI executable
+# $gitdir: Directory containing git repo
+# $gitbranch: Branch we are going to examine
+# $multipleclassiserror: Does multiple classes in test file raise error or just warning (default)
+
+# Don't be strict. Script has own error control handle
+set +e
+
+required="phpcmd gitdir gitbranch"
+for var in ${required}; do
+    if [ -z "${!var}" ]; then
+        echo "Error: ${var} environment variable is not defined. See the script comments."
+        exit 1
+    fi
+done
+
+# calculate some variables
+mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Ensure we are in the desired dir and branch
+cd $gitdir && git reset --quiet --hard $gitbranch && git clean -qdf
+
+# Let's build the phpunit.xml file for further analysis.
+${phpcmd} ${mydir}/create_phpunit_xml.php --basedir="${gitdir}"
+exitstatus=${PIPESTATUS[0]}
+if [ $exitstatus -ne 0 ]; then
+    echo "Problem creating the phpunit.xml file at ${gitdir}"
+    exit 1
+fi
+
+# Important! We are only interested in the test suites,
+# so we need to get rid of all the coverage information from the file now.
+sed -i '/<coverage>/,/<\/coverage>/d' phpunit.xml
+
+# MDLSITE-1972. Verify that all the test directories in codebase
+# are matched/covered by the definitions in the generated phpunit.xml.
+
+# Load all the defined tests
+definedtests=$(grep -r "directory suffix" ${gitdir}/phpunit.xml | sed 's/^[^>]*>\([^<]*\)<.*$/\1/g')
+# Load all the existing tests
+existingtests=$(cd ${gitdir} && find . -name tests | sed 's/^\.\/\(.*\)$/\1/g')
+# Some well-known "tests" that we can ignore here
+ignoretests=""
+
+# Unit test classes to look for with each file (must be 1 and only 1). MDLSITE-2096
+# TODO: Some day replace this with the list of abstract classes, using some classmap going up to phpunit top class.
+unittestclasses="
+    advanced_testcase
+    area_test_base
+    badgeslib_test
+    base_testcase
+    basic_testcase
+    cachestore_tests
+    core_backup_backup_restore_base_testcase
+    core_reportbuilder_testcase
+    data_loading_method_test_base
+    data_privacy_testcase
+    database_driver_testcase
+    externallib_advanced_testcase
+    googledocs_content_testcase
+    grade_base_testcase
+    lti_advantage_testcase
+    messagelib_test
+    mod_assign\\\\externallib_advanced_testcase
+    mod_lti_testcase
+    mod_quiz_attempt_walkthrough_from_csv_testcase
+    provider_testcase
+    qbehaviour_walkthrough_test_base
+    question_attempt_upgrader_test_base
+    question_testcase
+    repository_googledocs_testcase
+    restore_date_testcase
+"
+
+# Verify that each existing test is covered by some defined test
+# and that, all the test files have only one phpunit testcase class.
+for existing in ${existingtests}
+do
+    found=""
+    # Skip any existing test defined as ignoretests
+    if [[ ${ignoretests} =~ ${existing} ]]; then
+        echo "INFO: Ignoring ${existing}, not part of core."
+        continue
+    fi
+    for defined in ${definedtests}
+    do
+        if [[ ${existing} =~ ^${defined}$ ]]; then
+            echo "OK: ${existing} will be executed because there is a matching definition for it."
+            found="1"
+        elif [[ ${existing} =~ ^${defined}/.* ]]; then
+            echo "INFO: ${existing} will be executed because the ${defined} definition covers it."
+            found="1"
+        fi
+    done
+    if [[ -z ${found} ]]; then
+        # Last chance to skip, directory does not contain test units (files)
+        if [[ -z $(find ${existing} -name "*_test.php") ]]; then
+            echo "INFO: Ignoring ${existing}, it does not contain any test unit file."
+            continue;
+        fi
+        echo "ERROR: ${existing} is not matched/covered by any definition in phpunit.xml !"
+        exitstatus=1
+    fi
+    # Look inside all the test files, counting occurrences of $unittestclasses
+    unittestclassesregex=$(echo ${unittestclasses} | sed 's/ /|/g')
+    for testfile in $(ls ${existing} | grep "_test.php$")
+    do
+        # This is not the best (more accurate) regexp, but should be ok 99.99% of times.
+        classcount=$(grep -iP " extends *[\\\\]?(${unittestclassesregex}) ?.* {" ${existing}/${testfile} | wc -l | xargs)
+        if [[ ! ${classcount} -eq 1 ]]; then
+            if [[ "${multipleclassiserror}" == "yes" ]]; then
+                echo "ERROR: ${existing}/${testfile} has incorrect (${classcount}) number of unit test classes."
+                exitstatus=1
+            else
+                echo "WARNING: ${existing}/${testfile} has incorrect (${classcount}) number of unit test classes."
+            fi
+        fi
+    done
+done
+
+# This is everything we have added to the checkout, remove it.
+rm -fr ${gitdir}/phpunit.xml
+
+# If arrived here, return the exitstatus of the php execution
+exit $exitstatus


### PR DESCRIPTION
This light job does the following:

* Creates the phpunit.xml file (without requiring a whole site or database to be installed).
* Validates that all the "tests" directories in code base are covered by some suite in the phpunit.xml file. Errors if not (usually missing subsystem in phpunit.xml.dist file).
* Also reports (without failure) other "abnormal" situations like:
  * suite not having any _test.php file.
  * _test.php file not having any known unit test class (may require to inform about new parent class to the script).
  * _test.php file having multiple known unit tests classes. Warns by default, but can be configured to error too.

And that's all. Planning to add it to the post-checks @ integration.moodle.org, because it's quick and rarely happens (only when some new subsystem arrives). Like it has happened with 'course/format/tests" in 4.0. <= Will create issue as soon as this is up and running @ CIs.

Ciao :-)