### PR TITLE
All jobs moving issues to current integration must set clr = no

### DIFF
--- a/tracker_automations/continuous_manage_queues/lib.sh
+++ b/tracker_automations/continuous_manage_queues/lib.sh
@@ -99,7 +99,7 @@ function run_A2() {
         ${basereq} --action progressIssue \
                    --issue ${issue} \
                    --step "CI Global Self-Transition" \
-                   --custom "customfield_10211:Yes,customfield_10110:,customfield_10011:" \
+                   --custom "customfield_10211:Yes,customfield_15810:No,customfield_10110:,customfield_10011:" \
                    --comment "Continuous queues manage: Moving to current because it's important" \
                    --role "Integrators"
         echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue} moved to current: important" >> "${logfile}"
@@ -171,7 +171,7 @@ function run_A3a() {
             ${basereq} --action progressIssue \
                        --issue ${issue} \
                        --step "CI Global Self-Transition" \
-                       --custom "customfield_10211:Yes,customfield_10110:,customfield_10011:" \
+                       --custom "customfield_10211:Yes,customfield_15810:No,customfield_10110:,customfield_10011:" \
                        --comment "Continuous queues manage: Moving to current given we are below the threshold ($currentmin)" \
                        --role "Integrators"
             echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue} moved to current: threshold (before ${lastweekdate})" >> "${logfile}"
@@ -271,7 +271,7 @@ function run_B1b() {
             ${basereq} --action progressIssue \
                        --issue ${issue} \
                        --step "CI Global Self-Transition" \
-                       --custom "customfield_10211:Yes,customfield_10110:,customfield_10011:" \
+                       --custom "customfield_10211:Yes,customfield_15810:No,customfield_10110:,customfield_10011:" \
                        --comment "Continuous queues manage: Moving to current given we are below the threshold ($currentmin)" \
                        --role "Integrators"
             echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue} moved to current on-sync: threshold" >> "${logfile}"

--- a/tracker_automations/move_to_current_integration/move_to_current_integration.sh
+++ b/tracker_automations/move_to_current_integration/move_to_current_integration.sh
@@ -62,7 +62,7 @@ for issue in $( sed -n 's/^"\(MDL-[0-9]*\)".*/\1/p' "${resultfile}" ); do
     ${basereq} --action progressIssue \
         --issue ${issue} \
         --step "CI Global Self-Transition" \
-        --custom "customfield_10110:,customfield_10210:,customfield_10211:Yes,customfield_10011:" \
+        --custom "customfield_10110:,customfield_10210:,customfield_10211:Yes,customfield_15810:No,customfield_10011:" \
         --comment "Moving this issue to current integration cycle, will be reviewed soon. Thanks for the hard work!"
     ${basereq} --action removeLabels \
         --issue ${issue} \

--- a/tracker_automations/normal_manage_queues/lib.sh
+++ b/tracker_automations/normal_manage_queues/lib.sh
@@ -61,7 +61,7 @@ function run_A() {
         ${basereq} --action progressIssue \
                    --issue ${issue} \
                    --step "CI Global Self-Transition" \
-                   --custom "customfield_10211:Yes,customfield_10110:,customfield_10011:" \
+                   --custom "customfield_10211:Yes,customfield_15810:No,customfield_10110:,customfield_10011:" \
                    --comment "Normal queues manage: Moving to current because it's important" \
                    --role "Integrators"
         echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue} moved to current: important" >> "${logfile}"
@@ -133,7 +133,7 @@ function run_B() {
             ${basereq} --action progressIssue \
                        --issue ${issue} \
                        --step "CI Global Self-Transition" \
-                       --custom "customfield_10211:Yes,customfield_10110:,customfield_10011:" \
+                       --custom "customfield_10211:Yes,customfield_15810:No,customfield_10110:,customfield_10011:" \
                        --comment "Normal queues manage: Moving to current given we are below the threshold ($currentmin)" \
                        --role "Integrators"
             echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue} moved to current: threshold" >> "${logfile}"


### PR DESCRIPTION
All the issues arriving to current integration must have
the "Component Lead Review" field set to no, no matter if
the move is done by any of the queue managers or the bulk-move
that is executed on freeze day.

If they are kept empty / not set, that affects pickers because
one of the sorting criteria is that field.

Technically, all the places that are setting:

customfield_10211:Yes (Currently in integration = Yes)

Must, unconditionally, set:

customfield_15810:No (Component Lead Review = No)

That's exactly what this change does.