### PR TITLE
MDLSITE-6709 Avoid running the backup & external check for plugin runs

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -361,9 +361,12 @@ echo "Info: Running thirdparty..."
 ${mydir}/../thirdparty_check/thirdparty_check.sh > "${WORKSPACE}/work/thirdparty.txt"
 cat "${WORKSPACE}/work/thirdparty.txt" | ${phpcmd} ${mydir}/checkstyle_converter.php --format=thirdparty > "${WORKSPACE}/work/thirdparty.xml"
 
-echo "Info: Running missing external/backup stuff..."
-${mydir}/../upgrade_external_backup_check/upgrade_external_backup_check.sh > "${WORKSPACE}/work/externalbackup.txt"
-cat "${WORKSPACE}/work/externalbackup.txt" | ${phpcmd} ${mydir}/checkstyle_converter.php --format=thirdparty > "${WORKSPACE}/work/externalbackup.xml"
+# We skip this if the requested build is $isplugin
+if [[ -z "${isplugin}" ]]; then
+    echo "Info: Running missing external/backup stuff..."
+    ${mydir}/../upgrade_external_backup_check/upgrade_external_backup_check.sh > "${WORKSPACE}/work/externalbackup.txt"
+    cat "${WORKSPACE}/work/externalbackup.txt" | ${phpcmd} ${mydir}/checkstyle_converter.php --format=thirdparty > "${WORKSPACE}/work/externalbackup.xml"
+fi
 
 echo "Info: Running mustache lint..."
 ${mydir}/../mustache_lint/mustache_lint.sh > "${WORKSPACE}/work/mustachelint.txt"
@@ -493,8 +496,6 @@ rm ${WORKSPACE}/check_upgrade_savepoints.php
 # earlier in the script when the whole code-base was available. Now, for performance
 # reasons, only the patch-modified files are remaining so we cannot use phpcs abilities
 # to detect all components anymore. Hence using the complete, already calculated, list.
-# Note we need to specify where both moodle and PHPCompatibility, specifically the later, standards sit.
-# TODO: Some day this will work from the moodle ruleset.xml file, it doesn't right now.
 ${phpcmd} ${mydir}/../vendor/bin/phpcs \
     --runtime-set moodleComponentsListPath "${WORKSPACE}/work/valid_components.txt" \
     --report=checkstyle --report-file="${WORKSPACE}/work/cs.xml" \

--- a/tests/2-remote_branch_checker.bats
+++ b/tests/2-remote_branch_checker.bats
@@ -85,6 +85,12 @@ assert_prechecker () {
     assert_prechecker local_ci_fixture_upgrade_external_backup MDL-12345 c69c33b14d9fb83ca22bde558169e36b5e1047cf
 }
 
+@test "remote_branch_checker/remote_branch_checker.sh: upgrade external backup skipped for plugins" {
+    # With branches named PLUGIN-xxxx, the upgrade_external_backup check will be skipped,
+    # no matter the verified branch has 3 warnings when running for non plugins.
+    assert_prechecker local_ci_fixture_upgrade_external_backup_skipped_for_plugins PLUGIN-12345 c69c33b14d9fb83ca22bde558169e36b5e1047cf
+}
+
 @test "remote_branch_checker/remote_branch_checker.sh: phpcs aware of all components" {
     assert_prechecker local_ci_fixture_phpcs_aware_components MDL-12345 c69c33b14d9fb83ca22bde558169e36b5e1047cf
 }

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_external_backup_skipped_for_plugins.xml
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_external_backup_skipped_for_plugins.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<smurf version="0.9.1" numerrors="0" numwarnings="0">
+  <summary status="success" numerrors="0" numwarnings="0" condensedresult="smurf,success,0,0:phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0">
+    <detail name="phplint" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="phpcs" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="js" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="css" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="phpdoc" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="savepoint" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="thirdparty" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="grunt" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="shifter" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="mustache" status="success" numerrors="0" numwarnings="0"/>
+    <detail name="gherkin" status="success" numerrors="0" numwarnings="0"/>
+  </summary>
+  <check id="phplint" title="PHP lint problems" url="http://php.net/docs.php" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows php lint problems in the code detected by php -l</description>
+    <mess/>
+  </check>
+  <check id="phpcs" title="PHP coding style problems" url="https://docs.moodle.org/dev/Coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the coding style problems detected in the code by phpcs</description>
+    <mess/>
+  </check>
+  <check id="js" title="Javascript coding style problems" url="https://docs.moodle.org/dev/Javascript/Coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the coding style problems detected in the code by eslint</description>
+    <mess/>
+  </check>
+  <check id="css" title="CSS problems" url="https://docs.moodle.org/dev/CSS_coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows CSS problems detected by stylelint</description>
+    <mess/>
+  </check>
+  <check id="phpdoc" title="PHPDocs style problems" url="https://docs.moodle.org/dev/Coding_style" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows the phpdocs problems detected in the code by local_moodlecheck</description>
+    <mess/>
+  </check>
+  <check id="savepoint" title="Update savepoints problems" url="https://docs.moodle.org/dev/Upgrade_API" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows problems detected with the handling of upgrade savepoints</description>
+    <mess/>
+  </check>
+  <check id="thirdparty" title="Third party library modification problems" url="https://docs.moodle.org/dev/Peer_reviewing#Third_party_code" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows problems detected with the modification of third party libraries</description>
+    <mess/>
+  </check>
+  <check id="grunt" title="grunt changes" url="https://docs.moodle.org/dev/Grunt" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows files built by grunt and not commited</description>
+    <mess/>
+  </check>
+  <check id="shifter" title="shifter problems" url="https://docs.moodle.org/dev/YUI/Shifter" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows problems detected by shifter</description>
+    <mess/>
+  </check>
+  <check id="mustache" title="Mustache template problems" url="https://docs.moodle.org/dev/Templates" numerrors="0" numwarnings="0" allowfiltering="0">
+    <description>This section shows problems detected in mustache templates</description>
+    <mess/>
+  </check>
+  <check id="gherkin" title="Gherkin .feature problems" url="https://docs.moodle.org/dev/Writing_acceptance_tests" numerrors="0" numwarnings="0" allowfiltering="1">
+    <description>This section shows problems detected in behat .feature files</description>
+    <mess/>
+  </check>
+</smurf>


### PR DESCRIPTION
As far as we don't check the plugins incrementally (commit by commit)
like we do for normal MDL issues by CiBoT or PRs by moodle-plugin-ci,
this check is not useful for checks coming from the plugins database
(because they are just standard moodle branches + 1 unique commit
with all the plugin source code).

So we are disabling this check to be run when the source branches
are PLUGIN-xxx ones (we do the same for the commit check already).

Covered with tests.

PS: Also, delete old TODO comment that should have been deleted
few weeks ago, when another PR was merged.

Note this fixes/closes https://tracker.moodle.org/browse/MDLSITE-6709