### PR TITLE
Move from days to hours for timing better resolution

### DIFF
--- a/tests/libs/shared_setup.bash
+++ b/tests/libs/shared_setup.bash
@@ -128,12 +128,12 @@ restore_workspace() {
 # Clever idea, borrowed from https://github.com/dgholz/detect_virtualenv/blob/master/t/begin_and_end.bash
 # Are we in the first test of a file?
 function first_test() {
-  [ "$BATS_TEST_NUMBER" = 1 ]
+  [ "$BATS_TEST_NUMBER" -eq 1 ]
 }
 
 # Are we in the last test of a file?
 function last_test() {
-  [ "$BATS_TEST_NAME" = "${BATS_TEST_NAMES[@]:(-1)}" ]
+  [ "$BATS_TEST_NUMBER" -eq "${#BATS_TEST_NAMES[@]}" ]
 }
 
 # Clean up any $WORKSPACE state on every run.


### PR DESCRIPTION
We need to use hours instead of days, because the "AFTER -5d" is not accurate enough. In practice it accounts for 4.5 days, or something like that, hence the actions are happening some hours before they should. So, using hours (days * 24) to get more accurate results.

See some of the already processed issues like MDL-66273, MDL-74993 or MDL-75278... it's easy to see there how the reminder notification is happening after 4.5days (aprox), but before the 5 days configured.

Changing to hours will be way more accurate (max error will be just half an hour, not half a day). Note we already use this in other tracker automations, because of the accurateness.

Ciao :-)