### PR TITLE
Add renamed classes following MDL-75716

### DIFF
--- a/verify_phpunit_xml/verify_phpunit_xml.sh
+++ b/verify_phpunit_xml/verify_phpunit_xml.sh
@@ -65,6 +65,7 @@ unittestclasses="
     mod_assign\\\\externallib_advanced_testcase
     mod_lti_testcase
     mod_quiz_attempt_walkthrough_from_csv_testcase
+    mod_quiz\\\\attempt_walkthrough_from_csv_test
     provider_testcase
     qbehaviour_walkthrough_test_base
     question_attempt_upgrader_test_base


### PR DESCRIPTION
In MDL-75716, unit test class names were updated to match file names. As a result the parent class for a couple of tests was changed and must be added to the list of known parent classes.

The old location is not removed as they may still be legitimately used in older versions of Moodle.