### PR TITLE
Move away from MaxCDN to CloudFlare CDN

### DIFF
--- a/tracker_automations/bulk_precheck_issues/util.sh
+++ b/tracker_automations/bulk_precheck_issues/util.sh
@@ -32,19 +32,19 @@ function get_happy_image() {
     # marys pompoms (from https://tracker.moodle.org/browse/MDLSITE-3642)
     images[0]='https://tracker.moodle.org/secure/attachment/46622/AnimatedAmy.gif'
     # balloon🎈
-    images[1]='https://twemoji.maxcdn.com/16x16/1f388.png'
+    images[1]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f388.png'
     # party popper 🎉
-    images[2]='https://twemoji.maxcdn.com/16x16/1f389.png'
+    images[2]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f389.png'
     # clinking beer mugs 🍻
-    images[3]='https://twemoji.maxcdn.com/16x16/1f37b.png'
+    images[3]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f37b.png'
     # cookie 🍪
-    images[4]='https://twemoji.maxcdn.com/16x16/1f36a.png'
+    images[4]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f36a.png'
     # cake 🍰
-    images[5]='https://twemoji.maxcdn.com/16x16/1f370.png'
+    images[5]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f370.png'
     # glowing star 🌟
-    images[6]='https://twemoji.maxcdn.com/16x16/1f31f.png'
+    images[6]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f31f.png'
     # smiling face with halo 😇
-    images[7]='https://twemoji.maxcdn.com/16x16/1f607.png'
+    images[7]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f607.png'
 
     index=$[$RANDOM % ${#images[@]}]
     echo ${images[$index]}
@@ -52,21 +52,21 @@ function get_happy_image() {
 
 function get_sad_image() {
     # fire 🔥
-    images[0]='https://twemoji.maxcdn.com/16x16/1f525.png'
+    images[0]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f525.png'
     # pile of poo 💩
-    images[1]='https://twemoji.maxcdn.com/16x16/1f4a9.png'
+    images[1]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f4a9.png'
     # speak-no-evil monkey 🙊
-    images[2]='https://twemoji.maxcdn.com/16x16/1f64a.png'
+    images[2]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f64a.png'
     # bug 🐜
-    images[3]='https://twemoji.maxcdn.com/16x16/1f41c.png'
+    images[3]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f41c.png'
     # face screaming in fear 😱
-    images[4]='https://twemoji.maxcdn.com/16x16/1f631.png'
+    images[4]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f631.png'
     # construction sign 🚧
-    images[5]='https://twemoji.maxcdn.com/16x16/1f6a7.png'
+    images[5]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f6a7.png'
     # sos 🆘
-    images[6]='https://twemoji.maxcdn.com/16x16/1f198.png'
+    images[6]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f198.png'
     # skull 💀
-    images[7]='https://twemoji.maxcdn.com/16x16/1f480.png'
+    images[7]='https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f480.png'
 
     index=$[$RANDOM % ${#images[@]}]
     echo ${images[$index]}


### PR DESCRIPTION
MaxCDN has stopped serving the twemoji images, see:

https://github.com/twitter/twemoji/issues/580

So we are moving to cdnjs.cloudflare.com here so
all those tiny images used by CiBoT (some day we'll converted the majority of them to just Unicode emojis) continue working and making devs to smile a little bit.

This is a test to check that all them are working ok:

![pompoms](https://tracker.moodle.org/secure/attachment/46622/AnimatedAmy.gif) ![balloon](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f388.png) ![popper](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f389.png) ![beer](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f37b.png) ![cookie](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16//1f36a.png) ![cake](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f370.png) ![star](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f31f.png) ![smile](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f607.png)

![fire](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f525.png) ![poo](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f4a9.png) ![monkey](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f64a.png) ![bug](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f41c.png) ![fear](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16//1f631.png) ![construction](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f6a7.png) ![sos](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f198.png) ![skull](https://cdnjs.cloudflare.com/ajax/libs/twemoji/2.5/16x16/1f480.png)

