### PR TITLE
Change to PGSQL temporarily until we fix the recent issues with sqlsrv

### DIFF
--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/jobs.sh
@@ -6,11 +6,11 @@
 # and we need to keep it (until we move to REST from CLI)
 
 # We want to launch always a sqlsrv PHPUNIT
-echo -n "PHPUnit (sqlsrv): " >> "${resultfile}.jenkinscli"
+echo -n "PHPUnit (pgsql): " >> "${resultfile}.jenkinscli"
 ${jenkinsreq} "DEV.02 - Developer-requested PHPUnit" \
     -p REPOSITORY=${repository} \
     -p BRANCH=${branch} \
-    -p DATABASE=sqlsrv \
+    -p DATABASE=pgsql \
     -p PHPVERSION=${php_version} \
     -w >> "${resultfile}.jenkinscli" < /dev/null
 

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/jobs.sh
@@ -46,11 +46,11 @@ echo "Behat options: ${behat_options}"
 
 # We want to launch always a sqlsrv PHPUNIT
 if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "phpunit" ]]; then
-    echo -n "PHPUnit (sqlsrv / ${phpunit_options}): " >> "${resultfile}.jenkinscli"
+    echo -n "PHPUnit (pgsql / ${phpunit_options}): " >> "${resultfile}.jenkinscli"
     ${jenkinsreq} "DEV.02 - Developer-requested PHPUnit" \
         -p REPOSITORY=${repository} \
         -p BRANCH=${branch} \
-        -p DATABASE=sqlsrv \
+        -p DATABASE=pgsql \
         -p PHPVERSION=${php_version} \
         -p TAGS=${phpunit_filter} \
         -p TESTSUITE=${phpunit_suite} \


### PR DESCRIPTION
We have been getting some failed builds with database errors on sqlsrv runs, see https://github.com/moodlehq/moodle-php-apache/pull/164#issuecomment-1472883622

This commit changes the ToBiC and awaiting_for_integration runs to use pgsql database temporarily.