### PR TITLE
Ensure that the grunt job also runs non-default tasks

### DIFF
--- a/grunt_process/grunt_process.sh
+++ b/grunt_process/grunt_process.sh
@@ -53,14 +53,25 @@ else
 
     # Send both stdout and stderr to files while passing them intact (for callers consumption).
     # The echo here works around a problem where shifter is sending colours (MDL-52591).
+
     # Run the default task (same as specifying no arguments)
     tasks="default"
 
+    # Add some non-default tasks to the run
+    # TODO: This conditional block can be removed once we move to 311_STABLE
+    #       as minimum required branch. Just remove it and add "ignorefiles" go the next block.
     if grep -q ignorefiles Gruntfile.js
     then
         # In 3.2 and later run ignorefiles task
         tasks="$tasks ignorefiles"
     fi
+    # Since 3.11 we have split scripts for every task, let's check for their existence there.
+    nondefault="jsconfig jsdoc upgradablelibs"
+    for task in ${nondefault}; do
+        if [[ -r .grunt/tasks/${task}.js ]]; then
+            tasks="${tasks} ${task}"
+        fi
+    done
 
     set +e
     npx grunt $tasks --no-color > >(tee "${outputfile}") 2> >(tee "${outputfile}".stderr >&2)

--- a/tests/1-grunt_process.bats
+++ b/tests/1-grunt_process.bats
@@ -79,3 +79,18 @@ setup () {
     assert_output --partial " -e .eslintignore "
     assert_output --partial "OK: All modules are perfectly processed by grunt"
 }
+
+@test "grunt process: Problems generating jsdoc" {
+    # When something in the jsdoc annotations is incorrect and leads the grunt jsdoc task to fail
+
+    # Testing on 4.2.0 because there was an error there, fixed few weeks later by MDL-78323. So we don't need any fixture.
+    create_git_branch 402-stable v4.2.0
+
+    # Run test
+    ci_run grunt_process/grunt_process.sh
+
+    assert_failure
+    assert_output --partial "Running \"jsdoc:dist\" (jsdoc) task"
+    assert_output --partial "ERROR: Unable to parse a tag's type expression for source file"
+    assert_output --partial "grade/report/grader/amd/src/collapse.js in line 497"
+}

--- a/tests/libs/shared_setup.bash
+++ b/tests/libs/shared_setup.bash
@@ -5,18 +5,18 @@ load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 
 if [ -z $LOCAL_CI_TESTS_CACHEDIR ]; then
-    echo "Please define LOCAL_CI_TESTS_CACHEDIR" >&2
+    echo "Please define LOCAL_CI_TESTS_CACHEDIR"
     exit 1;
 fi
 
 if [ ! -d $LOCAL_CI_TESTS_CACHEDIR ]; then
-    echo "Please ensure LOCAL_CI_TESTS_CACHEDIR is a directory" >&2
+    echo "Please ensure LOCAL_CI_TESTS_CACHEDIR is a directory"
     exit 1
 fi
 
 if [ -z $LOCAL_CI_TESTS_GITDIR ]; then
-    echo "Please define LOCAL_CI_TESTS_GITDIR. It should be a git clone of moodle.git." >&2
-    echo "IT WILL CAUSE DESTRUCTIVE CHANGES TO THE GIT REPO, DO NOT SHARE IT WITH YOUR CODE!" >&2
+    echo "Please define LOCAL_CI_TESTS_GITDIR. It should be a git clone of moodle.git."
+    echo "IT WILL CAUSE DESTRUCTIVE CHANGES TO THE GIT REPO, DO NOT SHARE IT WITH YOUR CODE!"
     exit 1;
 else
     # Ensure $LOCAL_CI_TESTS_GITDIR does not have trailing slashes, it breaks various tests.
@@ -24,7 +24,7 @@ else
 fi
 
 if [ -z $LOCAL_CI_TESTS_PHPCS_DIR ]; then
-    echo "Please ensure LOCAL_CI_TESTS_PHPCS_DIR is set to the path to the phpcs standard" >&2
+    echo "Please ensure LOCAL_CI_TESTS_PHPCS_DIR is set to the path to the phpcs standard"
     exit 1
 fi
 
@@ -44,7 +44,7 @@ create_git_branch() {
 
     cd $gitdir
     $gitcmd checkout . -q
-    $gitcmd clean -fd -q
+    $gitcmd clean -fdx -q
     $gitcmd checkout -B $branch -q
     $gitcmd reset --hard $resetto -q
 
@@ -58,7 +58,7 @@ git_apply_fixture() {
 
     if [ ! -f $patch ];
     then
-        echo "Fixture named $patchname does not exist in fixtures directory" 1>&2
+        echo "Fixture named $patchname does not exist in fixtures directory"
         exit 1
     fi
 


### PR DESCRIPTION
This includes:
- ignorefiles (that was already being checked, no matter it's called by other tasks).
- jsconfig
- jsdoc
- upgradablelibs

Covered with a real test using Moodle v4.2.0, where jsdoc was failing and nobody noticed.