### PR TITLE
Bump vnu-jar to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "moodle-local_ci",
       "version": "0.0.1",
       "dependencies": {
-        "vnu-jar": "18.11.5"
+        "vnu-jar": "23.4.11"
       }
     },
     "node_modules/vnu-jar": {
-      "version": "18.11.5",
-      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-18.11.5.tgz",
-      "integrity": "sha512-XxTYLOUgQYdvIlAgX1BtxZiQ97/OKuBaEojqZdjMnjI+OXDkSyQGNGpzUQIQygeRrFVdQ1/eAVfiRE/iIlV0fg==",
+      "version": "23.4.11",
+      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-23.4.11.tgz",
+      "integrity": "sha512-lI5dzBYXtxhilNI7EeQ5iUduYnNBq7YWx4UjfBVLXfBQHnXYZSf3y3bpM0bSyDU6jy/+OyKV7nw4tzpR5lXSZg==",
       "engines": {
         "node": ">=0.10"
       }
@@ -22,9 +22,9 @@
   },
   "dependencies": {
     "vnu-jar": {
-      "version": "18.11.5",
-      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-18.11.5.tgz",
-      "integrity": "sha512-XxTYLOUgQYdvIlAgX1BtxZiQ97/OKuBaEojqZdjMnjI+OXDkSyQGNGpzUQIQygeRrFVdQ1/eAVfiRE/iIlV0fg=="
+      "version": "23.4.11",
+      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-23.4.11.tgz",
+      "integrity": "sha512-lI5dzBYXtxhilNI7EeQ5iUduYnNBq7YWx4UjfBVLXfBQHnXYZSf3y3bpM0bSyDU6jy/+OyKV7nw4tzpR5lXSZg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "description": "Tools for CI with Moodle",
   "private": true,
   "dependencies": {
-    "vnu-jar": "18.11.5"
+    "vnu-jar": "23.4.11"
   }
 }


### PR DESCRIPTION
We have had reports of valid HTML being rejected because it was not valid at the time of the release of the version of vnu-jar we were using.

The previous version was from 2018.

Bumping to latest - 2023.4.11