### PR TITLE
Add a new app (latest-test) job to ToBiC runs

### DIFF
--- a/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
@@ -14,7 +14,7 @@
 #criteria: "awaiting integration"...
 #schedulemins: Frecuency (in minutes) of the schedule (cron) of this job. IMPORTANT to ensure that they match or there will be issues processed more than once or skipped.
 #jobtype: defaulting to "all", allows to just pick one of the available jobs: phpunit, behat-chrome, behat-goutte, behat-all.
-#quiet: if enabled ("true"), don't perform any action in the Tracker.
+#quiet: if enabled ("true"), don't perform any action in the Tracker. When "false", perform Tracker actions.
 #restrictedto: name of the project (MDL) role we want to restrict the comment to. Blank means no restriction.
 
 
@@ -113,6 +113,10 @@ while read issue; do
             set +e
             . "${mydir}/criteria/${criteria}/jobs.sh"
             set -e
+            # Only if we have got some new job registered in ${resultfile}.jenkinscli
+            if [[ ! -f "${resultfile}.jenkinscli" ]]; then
+                continue
+            fi
             # Calculate the type, job names and build numbers
             regex="^([^:]+): Started ([^#]+) #([0-9]+)$"
             while read jobline; do

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_component_lead_review/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_component_lead_review/jobs.sh
@@ -14,21 +14,6 @@ ${jenkinsreq} "DEV.02 - Developer-requested PHPUnit" \
     -p PHPVERSION=${php_version} \
     -w >> "${resultfile}.jenkinscli" < /dev/null
 
-# Disabled for now, it's failing a lot :-(
-# We want to launch always a Behat (latest, @app only) job
-#echo -n "App tests (experimental): " >> "${resultfile}.jenkinscli"
-#${jenkinsreq} "DEV.01 - Developer-requested Behat" \
-#    -p REPOSITORY=${repository} \
-#    -p BRANCH=${branch} \
-#    -p DATABASE=pgsql \
-#    -p PHPVERSION=${php_version} \
-#    -p BROWSER=chrome \
-#    -p BEHAT_TOTAL_RUNS=1 \
-#    -p MOBILE_VERSION=latest \
-#    -p INSTALL_PLUGINAPP=true \
-#    -p TAGS=@app \
-#    -w >> "${resultfile}.jenkinscli" < /dev/null
-
 # We want to launch always a Behat (goutte) job
 echo -n "Behat (goutte - boost and classic): " >> "${resultfile}.jenkinscli"
 ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
@@ -61,5 +46,22 @@ if [[ ${target} == "master" ]]; then
         -p PHPVERSION=${php_version} \
         -p BROWSER=firefox \
         -p BEHAT_SUITE=classic \
+        -w >> "${resultfile}.jenkinscli" < /dev/null
+fi
+
+# We want to launch a Behat (latest-test, @app only) job
+# only if the target branch is master.
+if [[ ${target} == "master" ]]; then
+    echo -n "App tests (stable app version): " >> "${resultfile}.jenkinscli"
+    ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
+        -p REPOSITORY=${repository} \
+        -p BRANCH=${branch} \
+        -p DATABASE=pgsql \
+        -p PHPVERSION=${php_version} \
+        -p BROWSER=chrome \
+        -p BEHAT_INCREASE_TIMEOUT=3 \
+        -p MOBILE_VERSION=latest-test \
+        -p INSTALL_PLUGINAPP=ci \
+        -p TAGS="@app&&~@performance&&~@local_behatsnapshots&&~@ci_jenkins_skip" \
         -w >> "${resultfile}.jenkinscli" < /dev/null
 fi

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/jobs.sh
@@ -14,21 +14,6 @@ ${jenkinsreq} "DEV.02 - Developer-requested PHPUnit" \
     -p PHPVERSION=${php_version} \
     -w >> "${resultfile}.jenkinscli" < /dev/null
 
-# Disabled for now, it's failing a lot :-(
-# We want to launch always a Behat (latest, @app only) job
-#echo -n "App tests (experimental): " >> "${resultfile}.jenkinscli"
-#${jenkinsreq} "DEV.01 - Developer-requested Behat" \
-#    -p REPOSITORY=${repository} \
-#    -p BRANCH=${branch} \
-#    -p DATABASE=pgsql \
-#    -p PHPVERSION=${php_version} \
-#    -p BROWSER=chrome \
-#    -p BEHAT_TOTAL_RUNS=1 \
-#    -p MOBILE_VERSION=latest \
-#    -p INSTALL_PLUGINAPP=true \
-#    -p TAGS=@app \
-#    -w >> "${resultfile}.jenkinscli" < /dev/null
-
 # We want to launch always a Behat (goutte) job
 echo -n "Behat (goutte - boost and classic): " >> "${resultfile}.jenkinscli"
 ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
@@ -61,5 +46,22 @@ if [[ ${target} == "master" ]]; then
         -p PHPVERSION=${php_version} \
         -p BROWSER=firefox \
         -p BEHAT_SUITE=classic \
+        -w >> "${resultfile}.jenkinscli" < /dev/null
+fi
+
+# We want to launch a Behat (latest-test, @app only) job
+# only if the target branch is master.
+if [[ ${target} == "master" ]]; then
+    echo -n "App tests (stable app version): " >> "${resultfile}.jenkinscli"
+    ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
+        -p REPOSITORY=${repository} \
+        -p BRANCH=${branch} \
+        -p DATABASE=pgsql \
+        -p PHPVERSION=${php_version} \
+        -p BROWSER=chrome \
+        -p BEHAT_INCREASE_TIMEOUT=3 \
+        -p MOBILE_VERSION=latest-test \
+        -p INSTALL_PLUGINAPP=ci \
+        -p TAGS="@app&&~@performance&&~@local_behatsnapshots&&~@ci_jenkins_skip" \
         -w >> "${resultfile}.jenkinscli" < /dev/null
 fi

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/jobs.sh
@@ -58,24 +58,6 @@ if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "phpunit" ]]; then
         -w >> "${resultfile}.jenkinscli" < /dev/null
 fi
 
-# Disabled for now, it's failing a lot :-(
-# We want to launch always a Behat (latest, @app only) job
-#if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-app" ]]; then
-#echo -n "App tests (experimental): " >> "${resultfile}.jenkinscli"
-#${jenkinsreq} "DEV.01 - Developer-requested Behat" \
-#    -p REPOSITORY=${repository} \
-#    -p BRANCH=${branch} \
-#    -p DATABASE=pgsql \
-#    -p PHPVERSION=${php_version} \
-#    -p BROWSER=chrome \
-#    -p BEHAT_TOTAL_RUNS=1 \
-#    -p MOBILE_VERSION=latest \
-#    -p INSTALL_PLUGINAPP=true \
-#    -p TAGS=@app \
-#    -p RUNNERVERSION=${runner} \
-#    -w >> "${resultfile}.jenkinscli" < /dev/null
-#fi
-
 # We want to launch always a Behat (goutte) job
 if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-goutte" ]]; then
     echo -n "Behat (goutte - boost and classic / ${behat_options}): " >> "${resultfile}.jenkinscli"
@@ -137,4 +119,32 @@ if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${job
         -p NAME="${behat_name}" \
         -p RUNNERVERSION=${runner} \
         -w >> "${resultfile}.jenkinscli" < /dev/null
+fi
+
+# We want to launch a Behat (latest-test, @app only) job
+# only if the target branch is master.
+if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-app" ]]; then
+    # Only for master or when behat-app is explicitly asked.
+    if [[ ${target} == "master" ]] || [[ "${jobtype}" == "behat-app" ]]; then
+        echo -n "App tests (stable app version) / ${behat_options}): " >> "${resultfile}.jenkinscli"
+        # These are the default tags for any app run.
+        final_tags="@app&&~@performance&&~@local_behatsnapshots&&~@ci_jenkins_skip"
+        if [[ -n "${behat_tags}" ]]; then
+            # Add the specified tags, if any to the default ones.
+            final_tags="${final_tags}&&${behat_tags}"
+        fi
+        ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
+            -p REPOSITORY=${repository} \
+            -p BRANCH=${branch} \
+            -p DATABASE=pgsql \
+            -p PHPVERSION=${php_version} \
+            -p BROWSER=chrome \
+            -p BEHAT_INCREASE_TIMEOUT=3 \
+            -p MOBILE_VERSION=latest-test \
+            -p INSTALL_PLUGINAPP=ci \
+            -p TAGS="${final_tags}" \
+            -p NAME="${behat_name}" \
+            -p RUNNERVERSION=${runner} \
+            -w >> "${resultfile}.jenkinscli" < /dev/null
+    fi
 fi

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls_sdev/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls_sdev/jobs.sh
@@ -20,24 +20,6 @@ if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "phpunit" ]]; then
         -w >> "${resultfile}.jenkinscli" < /dev/null
 fi
 
-# Disabled for now, it's failing a lot :-(
-# We want to launch always a Behat (latest, @app only) job
-#if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-app" ]]; then
-#echo -n "App tests (experimental): " >> "${resultfile}.jenkinscli"
-#${jenkinsreq} "SDEV.01 - Developer-requested Behat" \
-#    -p REPOSITORY=${repository} \
-#    -p BRANCH=${branch} \
-#    -p DATABASE=pgsql \
-#    -p PHPVERSION=${php_version} \
-#    -p BROWSER=chrome \
-#    -p BEHAT_TOTAL_RUNS=1 \
-#    -p MOBILE_VERSION=latest \
-#    -p INSTALL_PLUGINAPP=true \
-#    -p TAGS=@app \
-#    -p RUNNERVERSION=${runner} \
-#    -w >> "${resultfile}.jenkinscli" < /dev/null
-#fi
-
 # We want to launch always a Behat (goutte) job
 if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-goutte" ]]; then
     echo -n "Behat (goutte - boost and classic): " >> "${resultfile}.jenkinscli"
@@ -77,4 +59,25 @@ if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${job
         -p BEHAT_SUITE=classic \
         -p RUNNERVERSION=${runner} \
         -w >> "${resultfile}.jenkinscli" < /dev/null
+fi
+
+# We want to launch a Behat (latest-test, @app only) job
+# only if the target branch is master.
+if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-app" ]]; then
+    # Only for master or when behat-app is explicitly asked.
+    if [[ ${target} == "master" ]] || [[ "${jobtype}" == "behat-app" ]]; then
+        echo -n "App tests (stable app version): " >> "${resultfile}.jenkinscli"
+        ${jenkinsreq} "SDEV.01 - Developer-requested Behat" \
+            -p REPOSITORY=${repository} \
+            -p BRANCH=${branch} \
+            -p DATABASE=pgsql \
+            -p PHPVERSION=${php_version} \
+            -p BROWSER=chrome \
+            -p BEHAT_INCREASE_TIMEOUT=3 \
+            -p MOBILE_VERSION=latest-test \
+            -p INSTALL_PLUGINAPP=ci \
+            -p TAGS="@app&&~@performance&&~@local_behatsnapshots&&~@ci_jenkins_skip" \
+            -p RUNNERVERSION=${runner} \
+            -w >> "${resultfile}.jenkinscli" < /dev/null
+    fi
 fi

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/multi_database/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/multi_database/jobs.sh
@@ -141,7 +141,35 @@ if [[ "${jobtype}" == "behat-firefox" ]]; then
             -p PHPVERSION=${php_version} \
             -p BROWSER=firefox \
             -p BEHAT_SUITE=default \
-            -p TAGS=${behat_tags} \
+            -p TAGS="${final_tags}" \
+            -p NAME="${behat_name}" \
+            -p RUNNERVERSION=${runner} \
+            -w >> "${resultfile}.jenkinscli" < /dev/null
+    done
+fi
+
+# This is a behat-app jobtype, let's launch it.
+if [[ "${jobtype}" == "behat-app" ]]; then
+    # Loop over all the configured dbtypes.
+    dbtypesarr=($(echo ${dbtypes} | tr ',' '\n'))
+    for dbtype in "${dbtypesarr[@]}"; do
+        dbtype=${dbtype//[[:blank:]]/}
+        echo -n "App tests (stable app version) - ${dbtype} / ${behat_options}): " >> "${resultfile}.jenkinscli"
+        # These are the default tags for any app run.
+        final_tags="@app&&~@performance&&~@local_behatsnapshots&&~@ci_jenkins_skip"
+        if [[ -n "${behat_tags}" ]]; then
+            # Add the specified tags, if any to the default ones.
+            final_tags="${final_tags}&&${behat_tags}"
+        fi
+        ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
+            -p REPOSITORY=${repository} \
+            -p BRANCH=${branch} \
+            -p DATABASE=${dbtype} \
+            -p PHPVERSION=${php_version} \
+            -p BROWSER=chrome \
+            -p BEHAT_INCREASE_TIMEOUT=3 \
+            -p MOBILE_VERSION=latest-test \
+            -p INSTALL_PLUGINAPP=ci \
             -p TAGS="${final_tags}" \
             -p NAME="${behat_name}" \
             -p RUNNERVERSION=${runner} \


### PR DESCRIPTION
Add a new app (latest-test) job to ToBiC runs:
- Only for master branch, unless the `behat-app` type is specified in jobs supporting it - aka, the manual "list_of_mdls" ones, not the automatic ones.
- Using the agreed tags: `@app&&~@performance&&~@local_behatsnapshots&&~@ci_jenkins_skip`
- Setting the behat timeout to 3 because the app is slow in the browser and may need some extra time here and there.
    
Everything else are standard job settings. Applied to the 5 job criteria.    
