### PR TITLE
Ensure the str helper is url/href compliant

### DIFF
--- a/mustache_lint/mustache_lint.php
+++ b/mustache_lint/mustache_lint.php
@@ -87,7 +87,7 @@ $jshelper = new js_helper($CFG->dirroot);
 $mustache = new Mustache_Engine([
     'pragmas' => [Mustache_Engine::PRAGMA_BLOCKS],
     'helpers' => [ // Emulate some helpers for html validation purposes.
-        'str' => function($text) { return "[[$text]]"; },
+        'str' => function($text) { return '((' . urlencode($text) . '))'; },
         'pix' => function($text) { return "<img src='pix-placeholder.png' alt='$text'>"; },
         'uniqid' => function() { return "would-be-a-uniqid"; },
         'quote' => function($text, $helper) {

--- a/tests/1-mustache_lint.bats
+++ b/tests/1-mustache_lint.bats
@@ -132,6 +132,21 @@ setup () {
     assert_failure
 }
 
+@test "mustache lint: Test str helper is working" {
+    # Set up.
+    create_git_branch MOODLE_402_STABLE v4.2.0
+    git_apply_fixture 402-mustache_lint-str.patch
+    export GIT_PREVIOUS_COMMIT=$FIXTURE_HASH_BEFORE
+    export GIT_COMMIT=$FIXTURE_HASH_AFTER
+
+    ci_run mustache_lint/mustache_lint.sh
+
+    # Assert result
+    assert_success
+    assert_output --partial "lib/templates/test_str.mustache - OK: Mustache rendered html succesfully"
+    assert_output --partial "No mustache problems found"
+}
+
 @test "mustache_lint: Test quote and uniq helpers are working" {
     # Set up.
     git_apply_fixture 31-mustache_lint-quote_and_uniq.patch

--- a/tests/fixtures/402-mustache_lint-str.patch
+++ b/tests/fixtures/402-mustache_lint-str.patch
@@ -1,0 +1,30 @@
+From d64cf216e6f0cdfed617b538fde5b4e193e7da88 Mon Sep 17 00:00:00 2001
+From: "Eloy Lafuente (stronk7)" <stronk7@moodle.org>
+Date: Tue, 11 Jul 2023 15:16:18 +0200
+Subject: [PATCH] MDL-12345: test str helper
+
+---
+ lib/templates/test_str.mustache | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+ create mode 100644 lib/templates/test_str.mustache
+
+diff --git a/lib/templates/test_str.mustache b/lib/templates/test_str.mustache
+new file mode 100644
+index 00000000000..cb7a906deb9
+--- /dev/null
++++ b/lib/templates/test_str.mustache
+@@ -0,0 +1,11 @@
++{{!
++    @template core/test_str
++
++    Example context (json):
++    {
++    }
++
++}}
++<p>{{#str}} string, component {{/str}}</p>
++<label data-type="{{#str}} string, component {{/str}}'">Label</label>
++<a href="{{#str}} string, component {{/str}}'">Link</a>
+-- 
+2.40.0
+


### PR DESCRIPTION
So we are:
- replacing the square brackets by parenthesis (allowed in URLs).
- urlenconding the str contents so they are also allowed links.

Backed by tests.

Fixes #270