### PR TITLE
MDLSITE-7296 Apply in the queue managers towards using rank

### DIFF
--- a/tracker_automations/continuous_manage_queues/continuous_manage_queues.sh
+++ b/tracker_automations/continuous_manage_queues/continuous_manage_queues.sh
@@ -122,7 +122,9 @@ if [ $behaviorAB == "before" ]; then
     # A1, add the "integration_held" + standard comment to any new feature or improvement arriving to candidates.
     run_A1
     # A2, move "important" issues from candidates to current
-    run_A2
+    # Note: This has been disabled as of 2023-07-13. See MDLSITE-7296 for more information.
+    echo "Automatism A2 disabled, not considering important issues any more"
+    # run_A2
     # A3, move all issues aways from candidates queue:
     if [ $behaviorA3 == "move" ]; then
         # A3a, keep the current queue fed with bug issues when it's under a threshold.

--- a/tracker_automations/continuous_manage_queues/lib.sh
+++ b/tracker_automations/continuous_manage_queues/lib.sh
@@ -131,9 +131,7 @@ function run_A3a() {
         ${basereq} --action getIssueList \
                    --jql "filter=14000 \
                        ORDER BY 'Integration priority' DESC, \
-                                priority DESC, \
-                                votes DESC, \
-                                'Last comment date' ASC" \
+                                Rank ASC" \
                    --file "${resultfile}"
 
         # Iterate over found issues, moving up to $movemax of them to the current queue (cleaning integrator and tester).
@@ -234,9 +232,7 @@ function run_B1b() {
         ${basereq} --action getIssueList \
                    --jql "filter=14000 \
                        ORDER BY 'Integration priority' DESC, \
-                                priority DESC, \
-                                votes DESC, \
-                                'Last comment date' ASC" \
+                                Rank ASC" \
                    --file "${resultfile}"
 
         # Iterate over found issues, moving up to $movemax of them to the current queue (cleaning integrator and tester).

--- a/tracker_automations/normal_manage_queues/lib.sh
+++ b/tracker_automations/normal_manage_queues/lib.sh
@@ -93,9 +93,7 @@ function run_B() {
         ${basereq} --action getIssueList \
                    --jql "filter=14000 \
                        ORDER BY 'Integration priority' DESC, \
-                                priority DESC, \
-                                votes DESC, \
-                                'Last comment date' ASC" \
+                                Rank ASC" \
                    --file "${resultfile}"
 
         # Iterate over found issues, moving up to $movemax of them to the current queue (cleaning integrator and tester).

--- a/tracker_automations/normal_manage_queues/normal_manage_queues.sh
+++ b/tracker_automations/normal_manage_queues/normal_manage_queues.sh
@@ -78,13 +78,17 @@ if [ -n "${dryrun}" ]; then
 fi
 
 # A, move "important" issues from candidates to current.
-run_A
+# Note: This has been disabled as of 2023-07-13. See MDLSITE-7296 for more information.
+echo "Automatism A disabled, not considering important issues any more"
+# run_A
 
 # B, keep the current queue fed with issues when it's under a threshold.
 run_B
 
 # C, raise interation priority for issues awaiting as candidates too long.
-run_C
+# Note: This has been disabled as of 2023-07-13. See MDLSITE-7296 for more information.
+echo "Automatism C disabled, not raising the integration priority of issues waiting too long any more"
+# run_C
 
 # Remove the resultfile. We don't want to disclose those details.
 rm -fr "${resultfile}"


### PR DESCRIPTION
This changes the picking order of both the [normal](https://ci.moodle.org/view/Tracker/job/TR%20-%20Manage%20queues%20on%20normal/) and the [continuous](https://ci.moodle.org/view/Tracker/job/TR%20-%20Manage%20queues%20on%20continuous/) queue managers from previous:

- Integration priority.
- Issue priority.
- Number of votes.
- Last update/comment.

To a new:

- Integration priority.
- Issue rank (calculated elsewhere).

Worth noting that, together with the move **we are also disabling a few previous automatisms**:

- Moving "important" issues from the candidates to the current queue. Now we are only moving issues by the new agreed sorting method above.
- Stop raising the integration priority to 1 for issues waiting in the queue for more than X (configurable) days.

Also, worth noting that we aren't changing at this stage the 2 jobs in charge of managing the Integration priority of issues:

- [set_integration_priority_to_zero.sh](https://ci.moodle.org/view/Tracker/job/TR%20-%20Set%20integration%20priority%20to%20zero/)
- [set_integration_priority_to_one.sh](https://ci.moodle.org/view/Tracker/job/TR%20-%20Set%20integration%20priority%20to%20one/)

And they continue applying for the same logic as previously to control such a priority, namely:

- Set the integration priority to 1 if the issue (any of):
  - Has the mdlqa label.
  - Has a Must fix X.Y version.
  - Has the security flag.
  - Comes from CLR
  - Is blocking others (and is not blocked by others).
- Set the integration priority to 0 if the issue (any of):
  - Has null integration priority.
  - Has been reopened.
  - Has integration priority = 1 and is blocked by others.