### PR TITLE
Treat Mustache "info" message as info, not problem

### DIFF
--- a/mustache_lint/mustache_lint.php
+++ b/mustache_lint/mustache_lint.php
@@ -237,7 +237,11 @@ function check_html_validation($content) {
         //TODO: Sure would be nice if we could 'guess' a more accurate line number here..
         $context = str_replace("\n", '', $problem->extract);
         $message = "HTML Validation {$problem->type}, line {$problem->lastLine}: {$problem->message} ({$context})";
-        print_problem('WARNING', $message);
+        if ($problem->type == 'info') {
+            print_message('INFO', $message);
+        } else {
+            print_problem('WARNING', $message);
+        }
     }
 }
 

--- a/tests/1-mustache_lint_plugins.bats
+++ b/tests/1-mustache_lint_plugins.bats
@@ -18,7 +18,8 @@ setup () {
     assert_failure
     assert_output --partial "Running mustache lint from $GIT_PREVIOUS_COMMIT to $GIT_COMMIT"
     assert_output --partial "local/test/templates/linting_ok.mustache - OK: Mustache rendered html succesfully"
-    assert_output --partial "local/test/templates/local/mobile/view.mustache - WARNING: HTML Validation info"
+    assert_output --partial "local/test/templates/local/mobile/view.mustache - INFO: HTML Validation info"
+    assert_output --partial "local/test/templates/local/mobile/view.mustache - WARNING: HTML Validation error"
     assert_output --partial "local/test/templates/mobile_view.mustache - WARNING: HTML Validation error"
     assert_output --partial "Mustache lint problems found"
 }


### PR DESCRIPTION
The Mustache lint seems to treat all HTML validation messages as problems, even if they are "info".

I have run into this recently, while checking my course format plugin.  I guess there's been a recent change to the HTML validator that's caused it?  A Mustache file failed validation because some included Moodle Mustache files closed HTML single tags with /> instead of just >.  I got the "info" message "Trailing slash on void elements has no effect and interacts badly with unquoted attribute values."  As far as I can tell, this message is only ever given when there is no actual problem, and if there is an actual problem with a trailing /, I think another, non-info message will likely be given.

I don't think it's necessary to treat "info" messages as problems, and I suspect it will now cause most course format plugins to fail validation in a way that's beyond the author's control.  (Not sure about other plugin types.)

I _think_ the suggested change should fix the issue, but I haven't actually figured out how to run it locally to check, so I don't really know.

I assume this plugin is used for GitHub actions, and the Moodle code prechecks?  If so, and this change is accepted, could you tell me how long it's likely to be before those use the update?