### PR TITLE
Move issues to the current queue by Rank

### DIFF
--- a/tracker_automations/continuous_manage_queues/lib.sh
+++ b/tracker_automations/continuous_manage_queues/lib.sh
@@ -130,8 +130,7 @@ function run_A3a() {
         # Get an ordered list of issues in the candidate queue.
         ${basereq} --action getIssueList \
                    --jql "filter=14000 \
-                       ORDER BY 'Integration priority' DESC, \
-                                Rank ASC" \
+                       ORDER BY Rank ASC" \
                    --file "${resultfile}"
 
         # Iterate over found issues, moving up to $movemax of them to the current queue (cleaning integrator and tester).
@@ -231,8 +230,7 @@ function run_B1b() {
         # Get an ordered list of issues in the candidate queue.
         ${basereq} --action getIssueList \
                    --jql "filter=14000 \
-                       ORDER BY 'Integration priority' DESC, \
-                                Rank ASC" \
+                       ORDER BY Rank ASC" \
                    --file "${resultfile}"
 
         # Iterate over found issues, moving up to $movemax of them to the current queue (cleaning integrator and tester).

--- a/tracker_automations/normal_manage_queues/lib.sh
+++ b/tracker_automations/normal_manage_queues/lib.sh
@@ -92,8 +92,7 @@ function run_B() {
         # Get an ordered list of up to issues in the candidate queue.
         ${basereq} --action getIssueList \
                    --jql "filter=14000 \
-                       ORDER BY 'Integration priority' DESC, \
-                                Rank ASC" \
+                       ORDER BY Rank ASC" \
                    --file "${resultfile}"
 
         # Iterate over found issues, moving up to $movemax of them to the current queue (cleaning integrator and tester).


### PR DESCRIPTION
In order for the current integration queue to reflect the ordering of issues in the integration backlog, the queues manager will now be moving issues by `Rank` instead of by `Integration priority` and then `Rank`.

It will be up to the product managers to rank all issues regardless of the issues' Integration priority. But it will still be highly encouraged to rank issues with `Integration priority=1` higher whenever possible.