### PR TITLE
Enable back (partially) the move from candidates to current

### DIFF
--- a/tracker_automations/continuous_manage_queues/continuous_manage_queues.sh
+++ b/tracker_automations/continuous_manage_queues/continuous_manage_queues.sh
@@ -25,12 +25,6 @@
 #  4) At least one of this is true:
 #    a) The issue has a must-fix version.                                 | => filter = 21363
 #    b) The issue has the mdlqa label.                                    | => labels IN (mdlqa)
-#    c) The issue priority is critical or higher.                         | => priority IN (Critical, Blocker)
-#    d) The issue is flagged as security issue.                           | => level IS NOT EMPTY
-#    e) The issue belongs to some of these components:                    | => component IN (...)
-#      - Privacy
-#      - Automated functional tests (behat)
-#      - Unit tests
 #
 # This job must be enabled only since freeze day to the end of on-sync period, when normal weeklies begin.
 # (see https://docs.moodle.org/dev/Release_process#5_weeks_prior)
@@ -123,8 +117,8 @@ if [ $behaviorAB == "before" ]; then
     run_A1
     # A2, move "important" issues from candidates to current
     # Note: This has been disabled as of 2023-07-13. See MDLSITE-7296 for more information.
-    echo "Automatism A2 disabled, not considering important issues any more"
-    # run_A2
+    # Note: This has been (partially) enabled again as of 2023-08-29. See MDLSITE-7296 for more information.
+    run_A2
     # A3, move all issues aways from candidates queue:
     if [ $behaviorA3 == "move" ]; then
         # A3a, keep the current queue fed with bug issues when it's under a threshold.

--- a/tracker_automations/continuous_manage_queues/lib.sh
+++ b/tracker_automations/continuous_manage_queues/lib.sh
@@ -60,10 +60,7 @@ function run_A2() {
                      AND NOT filter = 21366
                      AND (
                        filter = 21363 OR
-                       labels IN (mdlqa) OR
-                       priority IN (Critical, Blocker) OR
-                       level IS NOT EMPTY OR
-                       component IN ('Privacy', 'Automated functional tests (behat)', 'Unit tests')
+                       labels IN (mdlqa)
                      )" \
                --file "${resultfile}"
 


### PR DESCRIPTION
On continuous we want these "important" issues to be automatically moved to current integration, irrespectively of the "threshold" moves:
- The issue has a must-fix version. [OR]
- The issue has the mdlqa label.

Of course, only issues in the candidates queue, not held and not blocked by others.

Note that we have removed some of the old "important" criteria, namely:
- The issue priority is critical or higher.
- The issue is flagged as security issue.
- The issue belongs to some of these components:
  - Privacy
  - Automated functional tests (behat)
  - Unit tests

See [MDLSITE-7296](https://tracker.moodle.org/browse/MDLSITE-7296) for more info (comments around 29 August 2023).

Tested with [MDL-70371](https://tracker.moodle.org/browse/MDL-70371), seems to be working ok (that issue was a must-fix).