### PR TITLE
Add support to run just Chrome jobs

### DIFF
--- a/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
@@ -13,7 +13,7 @@
 #             Trios are colon separated, example: master:customfield_10111:7.3,....). All them required.
 #criteria: "awaiting integration"...
 #schedulemins: Frecuency (in minutes) of the schedule (cron) of this job. IMPORTANT to ensure that they match or there will be issues processed more than once or skipped.
-#jobtype: defaulting to "all", allows to just pick one of the available jobs: phpunit, behat-firefox, behat-nonjs, behat-all.
+#jobtype: defaulting to "all", allows to just pick one of the available jobs: phpunit, behat-(firefox|chrome|nonjs|all).
 #quiet: if enabled ("true"), don't perform any action in the Tracker. When "false", perform Tracker actions.
 #restrictedto: name of the project (MDL) role we want to restrict the comment to. Blank means no restriction.
 

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/jobs.sh
@@ -79,6 +79,47 @@ if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${job
         -w >> "${resultfile}.jenkinscli" < /dev/null
 fi
 
+# We want to launch sometimes a Behat (Chrome (js) - boost) job.
+if [[ "${jobtype}" == "behat-chrome" ]]; then
+    echo -n "Behat (Chrome - boost / ${behat_options}): " >> "${resultfile}.jenkinscli"
+    final_tags=
+    if [[ -n "${behat_tags}" ]]; then
+        # Add the @javascript tag, because this is a js run, and skip known chrome bug.
+        final_tags="${behat_tags}&&@javascript&&~@skip_chrome_zerosize"
+    fi
+    ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
+        -p REPOSITORY=${repository} \
+        -p BRANCH=${branch} \
+        -p DATABASE=pgsql \
+        -p PHPVERSION=${php_version} \
+        -p BROWSER="Chrome (js)" \
+        -p TAGS="${final_tags}" \
+        -p NAME="${behat_name}" \
+        -p RUNNERVERSION=${runner} \
+        -w >> "${resultfile}.jenkinscli" < /dev/null
+fi
+
+# We want to launch sometimes a Behat (Chrome (js) - classic) job.
+if [[ "${jobtype}" == "behat-chrome" ]]; then
+    echo -n "Behat (Chrome - classic / ${behat_options}): " >> "${resultfile}.jenkinscli"
+    final_tags=
+    if [[ -n "${behat_tags}" ]]; then
+        # Add the @javascript tag, because this is a js run, and skip known chrome bug.
+        final_tags="${behat_tags}&&@javascript&&~@skip_chrome_zerosize"
+    fi
+    ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
+        -p REPOSITORY=${repository} \
+        -p BRANCH=${branch} \
+        -p DATABASE=pgsql \
+        -p PHPVERSION=${php_version} \
+        -p BROWSER="Chrome (js)" \
+        -p BEHAT_SUITE=classic \
+        -p TAGS="${final_tags}" \
+        -p NAME="${behat_name}" \
+        -p RUNNERVERSION=${runner} \
+        -w >> "${resultfile}.jenkinscli" < /dev/null
+fi
+
 # We want to launch always a Behat (Firefox (js) - boost) job
 if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-firefox" ]]; then
     echo -n "Behat (Firefox - boost / ${behat_options}): " >> "${resultfile}.jenkinscli"

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls_sdev/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls_sdev/jobs.sh
@@ -34,6 +34,32 @@ if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${job
         -w >> "${resultfile}.jenkinscli" < /dev/null
 fi
 
+# We want to launch sometimes a Behat (Chrome (js) - boost) job.
+if [[ "${jobtype}" == "behat-chrome" ]]; then
+    echo -n "Behat (Chrome - boost): " >> "${resultfile}.jenkinscli"
+    ${jenkinsreq} "SDEV.01 - Developer-requested Behat" \
+        -p REPOSITORY=${repository} \
+        -p BRANCH=${branch} \
+        -p DATABASE=pgsql \
+        -p PHPVERSION=${php_version} \
+        -p BROWSER="Chrome (js)" \
+        -p RUNNERVERSION=${runner} \
+        -w >> "${resultfile}.jenkinscli" < /dev/null
+fi
+
+# We want to launch sometimes a Behat (Chrome (js) - classic) job.
+if [[ "${jobtype}" == "behat-chrome" ]]; then
+    echo -n "Behat (Chrome - classic): " >> "${resultfile}.jenkinscli"
+    ${jenkinsreq} "SDEV.01 - Developer-requested Behat" \
+        -p REPOSITORY=${repository} \
+        -p BRANCH=${branch} \
+        -p DATABASE=pgsql \
+        -p PHPVERSION=${php_version} \
+        -p BROWSER="Chrome (js)" \
+        -p BEHAT_SUITE=classic \
+        -p RUNNERVERSION=${runner} \
+        -w >> "${resultfile}.jenkinscli" < /dev/null
+
 # We want to launch always a Behat (Firefox (js) - boost) job
 if [[ "${jobtype}" == "all" ]] || [[ "${jobtype}" == "behat-all" ]] || [[ "${jobtype}" == "behat-firefox" ]]; then
     echo -n "Behat (Firefox - boost): " >> "${resultfile}.jenkinscli"

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/multi_database/jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/multi_database/jobs.sh
@@ -122,6 +122,32 @@ if [[ "${jobtype}" == "behat-nonjs" ]]; then
     done
 fi
 
+# This is a behat-chrome jobtype, let's launch it.
+if [[ "${jobtype}" == "behat-chrome" ]]; then
+    # Loop over all the configured dbtypes.
+    dbtypesarr=($(echo ${dbtypes} | tr ',' '\n'))
+    for dbtype in "${dbtypesarr[@]}"; do
+        dbtype=${dbtype//[[:blank:]]/}
+        echo -n "Behat (Chrome - boost - ${dbtype} / ${behat_options}): " >> "${resultfile}.jenkinscli"
+        final_tags=
+        if [[ -n "${behat_tags}" ]]; then
+            # Add the @javascript tag, because this is a js run, and skip known chrome bug.
+            final_tags="${behat_tags}&&@javascript&&~@skip_chrome_zerosize"
+        fi
+        ${jenkinsreq} "DEV.01 - Developer-requested Behat" \
+            -p REPOSITORY=${repository} \
+            -p BRANCH=${branch} \
+            -p DATABASE=${dbtype} \
+            -p PHPVERSION=${php_version} \
+            -p BROWSER="Chrome (js)" \
+            -p BEHAT_SUITE=default \
+            -p TAGS="${final_tags}" \
+            -p NAME="${behat_name}" \
+            -p RUNNERVERSION=${runner} \
+            -w >> "${resultfile}.jenkinscli" < /dev/null
+    done
+fi
+
 # This is a behat-firefox jobtype, let's launch it.
 if [[ "${jobtype}" == "behat-firefox" ]]; then
     # Loop over all the configured dbtypes.


### PR DESCRIPTION
By using the new "behat-chrome" jobtype, all the
configurable criteria now will launch chrome DEV jobs.

Note that Firefox continues being the default (more reliable) browser used by all criteria.