### PR TITLE
Make all the "holding" actions to apply both for IR & CLR

### DIFF
--- a/tests/1-compare_databases.bats
+++ b/tests/1-compare_databases.bats
@@ -108,18 +108,18 @@ teardown () {
 }
 
 @test "compare_databases/compare_databases.sh: problems are detected" {
-    # Locally, patch master (4.3dev), as of 20230803, so we introduce some differences.
-    create_git_branch compare_databases  a1d5d1b2f758a3178bff4c42883a477f4b1ea50c
+    # Locally, patch v4.3.0, so we introduce some differences. Then compare with upgraded v4.2.2.
+    create_git_branch v4_3_0_wrong v4.3.0
     git_apply_fixture compare_databases_wrong.patch
 
-    export gitbranchinstalled=compare_databases
-    export gitbranchupgraded=MOODLE_402_STABLE
+    export gitbranchinstalled=v4_3_0_wrong
+    export gitbranchupgraded=v4.2.2
 
     ci_run compare_databases/compare_databases.sh
     assert_failure
-    assert_output --partial 'Info: Origin branches: (1) MOODLE_402_STABLE'
-    assert_output --partial 'Info: Target branch: compare_databases'
-    assert_output --partial 'Info: Comparing compare_databases and upgraded MOODLE_402_STABLE'
+    assert_output --partial 'Info: Origin branches: (1) v4.2.2'
+    assert_output --partial 'Info: Target branch: v4_3_0_wrong'
+    assert_output --partial 'Info: Comparing v4_3_0_wrong and upgraded v4.2.2'
     assert_output --partial 'Problems found comparing databases!'
     assert_output --partial 'Number of errors: 6'
     assert_output --partial 'Column username of table user difference found in max_length: 200 !== 100'
@@ -131,6 +131,6 @@ teardown () {
     assert_output --partial 'Error: Problem comparing databases ci_installed_'
     assert_output --partial 'Error: Process ended with 1 errors'
     refute_output --partial 'Ok: Process ended without errors'
-    run [ -f $WORKSPACE/compare_databases_compare_databases_logfile.txt ]
+    run [ -f $WORKSPACE/compare_databases_v4_3_0_wrong_logfile.txt ]
     assert_success
 }

--- a/tracker_automations/continuous_manage_queues/continuous_manage_queues.sh
+++ b/tracker_automations/continuous_manage_queues/continuous_manage_queues.sh
@@ -5,14 +5,14 @@
 #
 # The automatisms are as follow:
 #  A) Before release only! (normally 5 weeks of continuous between freeze and release)
-#    1) Add the "integration_held" (+ standard comment) to new features & improvements issue missing it @ candidates.
+#    1) Add the "integration_held" (+ standard comment) to new features & improvements issue missing it @ candidates (IR & CLR).
 #    2) Move (if not blocked) "important" issues from candidates to current.
 #    3) Move (if not blocked) issues away from the candidates queue.
 #      a) Before a date (last week), keep the current queue fed with bug issues when it's under a threshold.
-#      b) After a date (last week), add the "integration_held" (+ standard comment) to bug issues.
+#      b) After a date (last week), add the "integration_held" (+ standard comment) to bug issues (IR & CLR).
 #  B) After release only! (normally 2 weeks of on-sync continuous after release)
 #    1) Move (if not blocked) issues away from the candidates queue.
-#      a) Add the "integration_held" (+ on-sync standard comment) to new features and improvements missing it @ candidates.
+#      a) Add the "integration_held" (+ on-sync standard comment) to new features and improv. missing it @ candidates (IR & CLR).
 #      b) Keep the current queue fed with bug issues when it's under a threshold.
 #  C) Move, always, all held issues awaiting for integration away from current integration.
 #

--- a/tracker_automations/continuous_manage_queues/lib.sh
+++ b/tracker_automations/continuous_manage_queues/lib.sh
@@ -14,17 +14,17 @@ for var in $required; do
     fi
 done
 
-# A1, add the "integration_held" + standard comment to any new feature or improvement arriving to candidates.
+# A1, add the "integration_held" + standard comment to any new feature or improvement arriving to candidates (IR & CLR)
 function run_A1() {
     # Note this could be done by one unique "runFromIssueList" action, but we are splitting
     # the search and the update in order to log all the closed issues within jenkins ($logfile)
 
-    # Basically get all the issues in the candidates queue (filter=14000), that are not bug
+    # Basically get all the issues in the candidates queues (filter=14000 OR filter=23329), that are not bug
     # and that haven't received any comment with the standard unholding text (NOT filter = 22054)
 
     # Get the list of issues.
     ${basereq} --action getIssueList \
-               --jql "filter=14000 \
+               --jql "(filter=14000 OR filter=23329) \
                      AND type IN ('New Feature', Improvement) \
                      AND NOT filter = 22054" \
                --file "${resultfile}"
@@ -179,11 +179,11 @@ function run_A3a() {
     fi
 }
 
-# A3b, add the "integration_held" + standard comment to any issue arriving to candidates.
+# A3b, add the "integration_held" + standard comment to any issue arriving to candidates (IR & CLR).
 function run_A3b() {
-    # Get the list of issues in the candidates queue. All them will be held with last week comment.
+    # Get the list of issues in the candidates queues (IR & CLR). All them will be held with last week comment.
     ${basereq} --action getIssueList \
-               --jql "filter=14000" \
+               --jql "filter=14000 OR filter=23329" \
                --file "${resultfile}"
 
     # Iterate over found issues, moving them to the current queue.
@@ -279,17 +279,17 @@ function run_B1b() {
     fi
 }
 
-# B1a, add the "integration_held" + standard on-sync comment to any new feature or improvement arriving to candidates.
+# B1a, add the "integration_held" + standard on-sync comment to any new feature or improvement arriving to candidates (IR & CLR).
 function run_B1a() {
     # Note this could be done by one unique "runFromIssueList" action, but we are splitting
     # the search and the update in order to log all the closed issues within jenkins ($logfile)
 
-    # Basically get all the issues in the candidates queue (filter=14000), that are not bug
+    # Basically get all the issues in the candidates queues (filter=14000 OR filter=23329), that are not bug
     # and that haven't received any comment with the standard unholding text (NOT filter = 22054)
 
     # Get the list of issues.
     ${basereq} --action getIssueList \
-               --jql "filter=14000 \
+               --jql "(filter=14000 OR filter=23329) \
                      AND type IN ('New Feature', Improvement) \
                      AND NOT filter = 22054" \
                --file "${resultfile}"


### PR DESCRIPTION
Now, all the actions related to holding issues:
- After freeze, any new feature or improvement.
- Last week, any issue type.
- While on-sync, any new feature and improvement.

Are managed both for issues awaiting for IR and awaiting for CLR, so the same outcome (hold issues) happen
exactly the same for both.

Note that we'll have to modify the manual release process slightly to remember to unhold issues from both queues, that will be documented @ https://moodledev.io/general/development/process/release once this is merged and working.