### PR TITLE
Mustache helper now trim JS contents before passing them to ESLint

### DIFF
--- a/mustache_lint/js_helper.php
+++ b/mustache_lint/js_helper.php
@@ -23,7 +23,10 @@ class js_helper {
      * @param Mustache_LambdaHelper $helper Used to render nested mustache variables.
      */
     public function add_js($content, Mustache_LambdaHelper $helper) {
-        $this->js .= $helper->render($content);
+        // Ensure the JS to be checked doesn't have any trailing whitespace (spaces or tabs)
+        // because of the position of the {{js}}...{{/js}} tags in the mustache file.
+        // This will avoid "no-trailing-spaces" false positives from eslint.
+        $this->js .= trim($helper->render($content), "\t ");
     }
 
     /**

--- a/mustache_lint/mustache_lint.php
+++ b/mustache_lint/mustache_lint.php
@@ -156,8 +156,10 @@ $eslintproblems = $jshelper->run_eslint();
 if ($eslintproblems === false) {
     // Not an error situation for now, because we might run in situations
     // where npm dependencies including eslint are not installed.
+    echo "INFO: ESLint did not run" . PHP_EOL;
     print_message('INFO', 'ESLint did not run');
 } else {
+    echo "INFO: ESLint did run" . PHP_EOL;
     // When we have no example context, parse errors are common because
     // there are missing variables in the js, thus we ignore them.
     $ignoreparseerrors = empty($example) ? true : false;


### PR DESCRIPTION
Now the JS helper is trimming JS contents
    
This solves some false positives when the mustache checker is validating (using eslint) all the `{{#js}}...{{/js}}` sections embedded within templates.

Added a new test covering a real case in v4.3.0 of some partial with white space around.
    
Also we have added a bit of extra information to output so we can assert better in tests if the ESLint check happened or no. Various tests are now looking for that new output.