### PR TITLE
Fixes the generation of displayname when integrateto is set to main

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -86,7 +86,7 @@ ${mydir}/../git_garbage_collector/git_garbage_collector.sh
 # to connect to it using jenkins cli..
 displayname=""
 if [[ -n "${BUILD_TAG}" ]] && [[ ! "${issue}" = "" ]] && [[ -n "${jenkinsserver}" ]]; then
-    if [[ "${integrateto}" = "master" ]]; then
+    if [[ "${integrateto}" = "master" ]] || [[ "${integrateto}" = "main" ]]; then
         displayname="#${BUILD_NUMBER}:${issue}"
     else
         if [[ ${integrateto} =~ ^MOODLE_([0-9]*)_STABLE$ ]]; then


### PR DESCRIPTION
This is currently setting an empty string when 'integrateto' is set to 'main', causing tools like mdk precheck to fail. E.g. 
https://integration.moodle.org/view/prechecker/job/Precheck%20remote%20branch/148255/console

That job uses MDL-79114-master as the branch name, but 'integrateto' is set to 'main' (see the job params), which results in the job failure. Running a job manually works fine, as long as integrateto is set to master.