### PR TITLE
Move from participants to JQL Tricks commentedByUser()

### DIFF
--- a/tests/0-setup.bats
+++ b/tests/0-setup.bats
@@ -19,7 +19,7 @@ load libs/shared_setup
     assert_success
 
     run $phpcs --version
-    assert_output --regexp "PHP_CodeSniffer version [0-9]+\.[0-9]+\.[0-9]+ \(stable\) by Squiz \(http://www.squiz.net\)"
+    assert_output --regexp "PHP_CodeSniffer version [0-9]+\.[0-9]+\.[0-9]+ \(stable\) by Squiz and PHPCSStandards"
 }
 
 @test "GNU grep installed" {

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_component_lead_review/query.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_component_lead_review/query.sh
@@ -2,7 +2,7 @@ ${basereq} --action getIssueList \
            --jql "project = 'Moodle' \
                  AND status = 'Waiting for component lead review' \
                  AND status WAS NOT 'Waiting for component lead review' ON '-${schedulemins}' \
-                 AND participants not in (tobic) \
+                 AND issue NOT IN commentedByUser('tobic') \
                  AND level IS EMPTY \
                  ORDER BY priority DESC, votes DESC, 'Last comment date' ASC" \
            --outputFormat 101 \

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/query.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/query.sh
@@ -2,7 +2,7 @@ ${basereq} --action getIssueList \
            --jql "project = 'Moodle' \
                  AND status = 'Waiting for integration review' \
                  AND status WAS NOT 'Waiting for integration review' ON '-${schedulemins}' \
-                 AND participants not in (tobic) \
+                 AND issue NOT IN commentedByUser('tobic') \
                  AND level IS EMPTY \
                  ORDER BY priority DESC, votes DESC, 'Last comment date' ASC" \
            --outputFormat 101 \


### PR DESCRIPTION
The original query was working wrongly sometimes, because of Jira re-indexing problems. And that was leading to some ToBiC jobs to be relaunched, when they should not.

We have confirmed that, after a re-index, the original query is back to work, but that's not nice-enough outcome.

So we have moved to the already installed JQL Tricks query that seems to be immune to the indexing problems and properly keeps out to all the issues where ToBiC already has participated (by adding a comment).

Note that it has been checked that the JQL Tricks extension is also available for Jira Cloud (with a change in the syntax), but will work there, so it's ok if we add this new use here.

Ref: https://www.j-tricks.com/jql-tricks-cloud-migration.html