### PR TITLE
Accept component names containing numbers

### DIFF
--- a/verify_commit_messages/amoslib.php
+++ b/verify_commit_messages/amoslib.php
@@ -325,7 +325,7 @@ class amos_script_parser {
         $newstyle = trim($newstyle);
 
         // See {@link PARAM_COMPONENT}.
-        if (!preg_match('/^[a-z]+(_[a-z][a-z0-9_]*)?[a-z0-9]+$/', $newstyle)) {
+        if (!preg_match('/^[a-z][a-z0-9]*(_[a-z][a-z0-9_]*)?[a-z0-9]+$/', $newstyle)) {
             return false;
         }
 


### PR DESCRIPTION
Since MDL-67063, the format for the plugin type part of the component names in Moodle LMS consists of a letter followed by a combination of letters and numeric characters.

The changes have not been implemented in the legacy_component_name method.