### PR TITLE
Move tests to use PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setting up PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           ini-values: max_input_vars=5000
           tools: composer
           coverage: none

--- a/tests/1-compare_databases.bats
+++ b/tests/1-compare_databases.bats
@@ -48,89 +48,89 @@ teardown () {
     assert_output --partial 'Error: dbtype environment variable is not defined. See the script comments.'
 }
 
-@test "compare_databases/compare_databases.sh: single actual (> 401_STABLE) branch runs work" {
-    # TODO: Change this to stable branches when we have more supporting php82.
+@test "compare_databases/compare_databases.sh: single actual (> 403_STABLE) branch runs work" {
+    # TODO: Change this to stable branches when we have more supporting php83.
     export gitbranchinstalled=main
-    export gitbranchupgraded=MOODLE_402_STABLE
+    export gitbranchupgraded=MOODLE_404_STABLE
 
     ci_run compare_databases/compare_databases.sh
     assert_success
-    assert_output --partial 'Info: Origin branches: (1) MOODLE_402_STABLE'
-    assert_output --partial 'Info: Target branch: main'
-    assert_output --partial 'Info: Installing Moodle main into ci_installed_'
-    assert_output --partial 'Info: Comparing main and upgraded MOODLE_402_STABLE'
-    assert_output --partial 'Info: Installing Moodle MOODLE_402_STABLE into ci_upgraded_'
-    assert_output --partial 'Info: Upgrading Moodle MOODLE_402_STABLE to main into ci_upgraded_'
-    assert_output --partial 'Info: Comparing databases ci_installed_'
-    assert_output --partial 'Info: OK. No problems comparing databases ci_installed_'
-    assert_output --partial 'Ok: Process ended without errors'
-    refute_output --partial 'Error: Process ended with'
-    run [ -f $WORKSPACE/compare_databases_main_logfile.txt ]
+    assert_output --partial "Info: Origin branches: (1) ${gitbranchupgraded}"
+    assert_output --partial "Info: Target branch: ${gitbranchinstalled}"
+    assert_output --partial "Info: Installing Moodle ${gitbranchinstalled} into ci_installed_"
+    assert_output --partial "Info: Comparing ${gitbranchinstalled} and upgraded ${gitbranchupgraded}"
+    assert_output --partial "Info: Installing Moodle ${gitbranchupgraded} into ci_upgraded_"
+    assert_output --partial "Info: Upgrading Moodle ${gitbranchupgraded} to ${gitbranchinstalled} into ci_upgraded_"
+    assert_output --partial "Info: Comparing databases ci_installed_"
+    assert_output --partial "Info: OK. No problems comparing databases ci_installed_"
+    assert_output --partial "Ok: Process ended without errors"
+    refute_output --partial "Error: Process ended with"
+    run [ -f "${WORKSPACE}/compare_databases_${gitbranchinstalled}_logfile.txt" ]
     assert_success
 }
 
-@test "compare_databases/compare_databases.sh: single old (<= 402_STABLE) branch runs work" {
-    # TODO: Change this to versions corresponding to different branches when we have more supporting php82-
-    export gitbranchinstalled=v4.2.1
-    export gitbranchupgraded=v4.2.0
+@test "compare_databases/compare_databases.sh: single old (<= 404_STABLE) branch runs work" {
+    # TODO: Change this to versions corresponding to different branches when we have more supporting php83-
+    export gitbranchinstalled=main
+    export gitbranchupgraded=v4.4.0-beta
 
     ci_run compare_databases/compare_databases.sh
     assert_success
-    assert_output --partial 'Info: Origin branches: (1) v4.2.0'
-    assert_output --partial 'Info: Target branch: v4.2.1'
-    assert_output --partial 'Info: Installing Moodle v4.2.1 into ci_installed_'
-    assert_output --partial 'Info: Comparing v4.2.1 and upgraded v4.2.0'
-    assert_output --partial 'Info: Installing Moodle v4.2.0 into ci_upgraded_'
-    assert_output --partial 'Info: Upgrading Moodle v4.2.0 to v4.2.1 into ci_upgraded_'
-    assert_output --partial 'Info: Comparing databases ci_installed_'
-    assert_output --partial 'Info: OK. No problems comparing databases ci_installed_'
-    assert_output --partial 'Ok: Process ended without errors'
-    refute_output --partial 'Error: Process ended with'
-    run [ -f $WORKSPACE/compare_databases_v4.2.1_logfile.txt ]
+    assert_output --partial "Info: Origin branches: (1) ${gitbranchupgraded}"
+    assert_output --partial "Info: Target branch: ${gitbranchinstalled}"
+    assert_output --partial "Info: Installing Moodle ${gitbranchinstalled} into ci_installed_"
+    assert_output --partial "Info: Comparing ${gitbranchinstalled} and upgraded ${gitbranchupgraded}"
+    assert_output --partial "Info: Installing Moodle ${gitbranchupgraded} into ci_upgraded_"
+    assert_output --partial "Info: Upgrading Moodle ${gitbranchupgraded} to ${gitbranchinstalled} into ci_upgraded_"
+    assert_output --partial "Info: Comparing databases ci_installed_"
+    assert_output --partial "Info: OK. No problems comparing databases ci_installed_"
+    assert_output --partial "Ok: Process ended without errors"
+    refute_output --partial "Error: Process ended with"
+    run [ -f "${WORKSPACE}/compare_databases_${gitbranchinstalled}_logfile.txt" ]
     assert_success
 }
 
 @test "compare_databases/compare_databases.sh: multiple branch runs work" {
-    # TODO: Change this to different stable branches when we have more supporting php82.
+    # TODO: Change this to different stable branches when we have more supporting php83.
     export gitbranchinstalled=main
-    export gitbranchupgraded=v4.2.1,MOODLE_402_STABLE
+    export gitbranchupgraded=v4.4.0,MOODLE_404_STABLE
 
     ci_run compare_databases/compare_databases.sh
     assert_success
-    assert_output --partial 'Info: Origin branches: (2) v4.2.1,MOODLE_402_STABLE'
-    assert_output --partial 'Info: Target branch: main'
-    assert_output --partial 'Info: Comparing main and upgraded v4.2.1'
-    assert_output --partial 'Info: Comparing main and upgraded MOODLE_402_STABLE'
-    assert_output --partial 'Ok: Process ended without errors'
-    refute_output --partial 'Error: Process ended with'
-    run [ -f $WORKSPACE/compare_databases_main_logfile.txt ]
+    assert_output --partial "Info: Origin branches: (2) ${gitbranchupgraded}"
+    assert_output --partial "Info: Target branch: ${gitbranchinstalled}"
+    assert_output --partial "Info: Comparing ${gitbranchinstalled} and upgraded v4.4.0"
+    assert_output --partial "Info: Comparing ${gitbranchinstalled} and upgraded MOODLE_404_STABLE"
+    assert_output --partial "Ok: Process ended without errors"
+    refute_output --partial "Error: Process ended with"
+    run [ -f "${WORKSPACE}/compare_databases_${gitbranchinstalled}_logfile.txt" ]
     assert_success
 }
 
 @test "compare_databases/compare_databases.sh: problems are detected" {
-    # Locally, patch v4.3.0, so we introduce some differences. Then compare with upgraded v4.2.2.
-    create_git_branch v4_3_0_wrong v4.3.0
+    # Locally, patch v4.4.0, so we introduce some differences. Then compare with upgraded v4.3.0.
+    create_git_branch v4_4_0_wrong v4.4.0
     git_apply_fixture compare_databases_wrong.patch
 
-    export gitbranchinstalled=v4_3_0_wrong
-    export gitbranchupgraded=v4.2.2
+    export gitbranchinstalled=v4_4_0_wrong
+    export gitbranchupgraded=v4.3.0
 
     ci_run compare_databases/compare_databases.sh
     assert_failure
-    assert_output --partial 'Info: Origin branches: (1) v4.2.2'
-    assert_output --partial 'Info: Target branch: v4_3_0_wrong'
-    assert_output --partial 'Info: Comparing v4_3_0_wrong and upgraded v4.2.2'
-    assert_output --partial 'Problems found comparing databases!'
-    assert_output --partial 'Number of errors: 6'
-    assert_output --partial 'Column username of table user difference found in max_length: 200 !== 100'
-    assert_output --partial 'Column firstaccess of table user difference found in not_null: false !== true'
-    assert_output --partial 'Column firstaccess of table user difference found in default_value: 1 !== 0'
-    assert_output --partial 'Column trackforums of table user difference found in type: varchar !== tinyint'
-    assert_output --partial 'Column trackforums of table user difference found in max_length: 1 !== 2'
-    assert_output --partial 'Column trackforums of table user difference found in meta_type: C !== I'
-    assert_output --partial 'Error: Problem comparing databases ci_installed_'
-    assert_output --partial 'Error: Process ended with 1 errors'
-    refute_output --partial 'Ok: Process ended without errors'
-    run [ -f $WORKSPACE/compare_databases_v4_3_0_wrong_logfile.txt ]
+    assert_output --partial "Info: Origin branches: (1) ${gitbranchupgraded}"
+    assert_output --partial "Info: Target branch: ${gitbranchinstalled}"
+    assert_output --partial "Info: Comparing ${gitbranchinstalled} and upgraded ${gitbranchupgraded}"
+    assert_output --partial "Problems found comparing databases!"
+    assert_output --partial "Number of errors: 6"
+    assert_output --partial "Column username of table user difference found in max_length: 200 !== 100"
+    assert_output --partial "Column firstaccess of table user difference found in not_null: false !== true"
+    assert_output --partial "Column firstaccess of table user difference found in default_value: 1 !== 0"
+    assert_output --partial "Column trackforums of table user difference found in type: varchar !== tinyint"
+    assert_output --partial "Column trackforums of table user difference found in max_length: 1 !== 2"
+    assert_output --partial "Column trackforums of table user difference found in meta_type: C !== I"
+    assert_output --partial "Error: Problem comparing databases ci_installed_"
+    assert_output --partial "Error: Process ended with 1 errors"
+    refute_output --partial "Ok: Process ended without errors"
+    run [ -f "${WORKSPACE}/compare_databases_${gitbranchinstalled}_logfile.txt" ]
     assert_success
 }


### PR DESCRIPTION
Only the compare_databases need some tricks because we still have only 4.4.0 tag and 404 and main branches supporting php83. As soon as we have more branches supporting that php version, we'll amend the tests.