### PR TITLE
Add autoloader to verify_phpunit_xml

### DIFF
--- a/tests/verify_phpunit_xml.bats
+++ b/tests/verify_phpunit_xml.bats
@@ -13,7 +13,7 @@ teardown () {
     last_test || store_workspace
 }
 
-@test "verify_phpunit_xml: normal run without errors" {
+@test "verify_phpunit_xml: normal run without errors (old branch)" {
     ci_run verify_phpunit_xml/verify_phpunit_xml.sh
 
     assert_success
@@ -21,6 +21,19 @@ teardown () {
     assert_output --partial "INFO: backup/util/ui/tests will be executed because the backup/util definition"
     assert_output --partial "INFO: Ignoring admin/tests, it does not contain any test unit file."
     assert_output --partial "WARNING: message/tests/api_test.php has incorrect (0) number of unit test classes."
+    refute_output --partial "ERROR"
+}
+
+@test "verify_phpunit_xml: normal run without errors and warnings (main branch)" {
+    create_git_branch main origin/main
+
+    ci_run verify_phpunit_xml/verify_phpunit_xml.sh
+
+    assert_success
+    assert_output --partial "OK: competency/tests will be executed"
+    assert_output --partial "INFO: backup/util/ui/tests will be executed because the backup/util definition"
+    assert_output --partial "INFO: Ignoring privacy/classes/tests, it does not contain any test unit file."
+    refute_output --partial "WARNING"
     refute_output --partial "ERROR"
 }
 

--- a/verify_phpunit_xml/create_phpunit_xml.php
+++ b/verify_phpunit_xml/create_phpunit_xml.php
@@ -79,6 +79,10 @@ if (!load_core_component_from_moodle($options['basedir'])) {
     cli_error('Something went wrong. Components not loaded from ' . $options['basedir']);
 }
 
+// We need to register the Moodle autoloader.
+require_once($options['basedir'] . '/lib/classes/component.php');
+spl_autoload_register([\core_component::class, 'classloader']);
+
 // Now, let's invoke phpunit utils to generate the phpunit.xml file
 
 // We need to load a few stuff.


### PR DESCRIPTION
Tested locally.
I'm not sure how I can add a test for this in bats because it's only broken by a change in core which requires an autoloaded class in lib/outputcomponents.php. We could switch from 3.11 to main for testing?