### PR TITLE
For 4.5dev and up, let's detect any change to upgrade files

### DIFF
--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_txt_for_404.regex
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_txt_for_404.regex
@@ -1,0 +1,6 @@
+# Add here as many extended regular expressions (one by line)
+# that match the most relevant aspects of the test being executed
+# and its smurf.xml results.
+
+condensedresult="smurf,success,0,0:overview,success,0,0
+<detail name="overview" status="success" numerrors="0" numwarnings="0"/>

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_txt_for_405.regex
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_txt_for_405.regex
@@ -1,0 +1,7 @@
+# Add here as many extended regular expressions (one by line)
+# that match the most relevant aspects of the test being executed
+# and its smurf.xml results.
+
+condensedresult="smurf,error,1,0:overview,error,1,0
+<detail name="overview" status="error" numerrors="1" numwarnings="0"/>
+<message>The patchset contains changes to upgrade.txt or UPGRADING.md files.</message>

--- a/tests/remote_branch_checker.bats
+++ b/tests/remote_branch_checker.bats
@@ -162,3 +162,16 @@ assert_prechecker () {
     # This is just how it will fail because we don't want to run the entire testsuite..
     assert_output --partial "Error: Unable to fetch information from a-branch-which-doesnt-exist branch at https://github.com/moodle/moodle.git"
 }
+
+@test "remote_branch_222checker/remote_branch_checker.sh: detect changes to upgrade.txt and UPGRADING.md (<4.5)" {
+    export rebasewarn=999999 # Dont' warn about rebase ever.
+    export rebaseerror=999999 # Don't fail about rebase ever.
+    assert_prechecker local_ci_fixture_upgrade_txt_for_404 MDL-12345 v4.4.0
+}
+
+@test "remote_branch_checker/remote_branch_checker.sh: detect changes to upgrade.txt and UPGRADING.md (>=4.5)" {
+    export rebasewarn=999999 # Dont' warn about rebase ever.
+    export rebaseerror=999999 # Don't fail about rebase ever.
+    # Use 4.5dev (d32844ce296), May 2024, as the base commit.
+    assert_prechecker local_ci_fixture_upgrade_txt_for_405 MDL-12345 d32844ce296
+}


### PR DESCRIPTION
This includes both:
 - upgrade.txt files, that shouldn't be modified ever.
 - UPGRADING.md files, which are 100% managed by mdlrelease.

Note that, if some day we change something in the tool generating the UPGRADING.md files and we apply it as part of an issue, the check will report it as an error, but sure that we can consider that a false positive and proceed to integrate it.

In the other side, 99% of editions won't be legit, hence real positives.