### PR TITLE
Use the patch HEAD commit to name the branches

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -256,7 +256,9 @@ set -e
 # The merge succeded, now push our precheck branch for inspection:
 if [ ! -z ${pushremote} ]; then
     echo "Info: Pushing precheck branch to remote"
-    pushbranchname=${issue}-${integrateto}-$(git rev-list -n1 --abbrev-commit HEAD)
+    # Let's name the branches using 16 chars short commit of the branch being
+    # analysed, that way we can know which commits have been already checked.
+    pushbranchname=${issue}-${integrateto}-$(git rev-parse --short=16 FETCH_HEAD)
     $gitcmd push $pushremote ${integrateto}_precheck:${pushbranchname}
 fi
 


### PR DESCRIPTION
Before this, we were using the merge commit to name the branches to be pushed. That's useless information because on every merge the commit is different.

Instead, we are going to start using the patch HEAD commit (available in FETCH_HEAD) to name the branches, because that's some information that can be useful if some day we want to start checking what has been already checked and other niceties.

Note that we are forcing to use a short commit length of 16 (to have it homogeneus), no matter that given our moodle.git repo size we are still only needing 11 right now. So any future search will need to be aware of this detail.