### PR TITLE
Report list of files from merge conflicts

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -255,7 +255,7 @@ if [[ ${exitstatus} -ne 0 ]]; then
         echo "Error: Merge conflict(s) in file(s):" | tee -a ${errorfile}
         echo "${mergeconflicts}" | sed 's/^/Error: /' | tee -a ${errorfile}
     fi
-    
+
     exit ${exitstatus}
 fi
 set -e

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -249,6 +249,13 @@ ${gitcmd} merge -q --no-edit FETCH_HEAD
 exitstatus=${PIPESTATUS[0]}
 if [[ ${exitstatus} -ne 0 ]]; then
     echo "Error: The ${branch} branch at ${remote} does not apply clean to ${baseref}" | tee -a ${errorfile}
+
+    mergeconflicts="$( ${gitcmd} diff --name-only --diff-filter=U )"
+    if [[ -n "${mergeconflicts}" ]]; then
+        echo "Error: Merge conflict(s) in file(s):" | tee -a ${errorfile}
+        echo "${mergeconflicts}" | sed 's/^/Error: /' | tee -a ${errorfile}
+    fi
+    
     exit ${exitstatus}
 fi
 set -e


### PR DESCRIPTION
When we experience merge conflicts in the CiBot Precheck it would be nice to have more information than just: "does not apply clean", e.g. https://integration.moodle.org/job/Precheck%20remote%20branch/160991/artifact/work/errors.txt/*view*/

This adds the output from `git diff --name-only --diff-filter=U`, which provides the list of files not merged because of a conflict.