### PR TITLE
Post ToBiC and CiBoT results in the dedicated fields in the Tracker 

### DIFF
--- a/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
@@ -140,6 +140,7 @@ while read issue; do
             rm "${resultfile}.jenkinscli"
         fi
     done
+    echo "Built on: $(date -u)" >> "${resultfile}.${issue}.txt"
 
     echo ""
     # Verify we have processed some branch.

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/postissue.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/postissue.sh
@@ -1,10 +1,5 @@
-# Add the comment with results.
-if [[ -n "${restrictedto}" ]]; then
-    ${basereq} --action addComment \
-        --issue ${issue} \
-        --file "${resultfile}.${issue}.txt" ${restrictiontype} "${restrictedto}"
-else
-    ${basereq} --action addComment \
-        --issue ${issue} \
-        --file "${resultfile}.${issue}.txt"
-fi
+# Update the automated testing field with the results.
+${basereq} --action setFieldValue \
+    --issue ${issue} \
+    --field "Automated test results" \
+    --file "${resultfile}.${issue}.txt"


### PR DESCRIPTION
* CiBoT results will be posted in the "Pre-check results" field.
* ToBiC results will be posted in the "Automated test results" field.
* The queries for bulk pre-launch jobs for awaiting IR/CLR have been updated to check for issues updated by ToBiC `$schedulemins`  (default 120 mins) since the issue was sent to CLR/IR.
* A build time has also been added to the Bulk pre-launch jobs.