### PR TITLE
Post the CiBoT and ToBiC results in dedicated custom fields in the Tracker (part 2)

### DIFF
--- a/tracker_automations/bulk_precheck_issues/criteria/awaiting_integration/postissue.sh
+++ b/tracker_automations/bulk_precheck_issues/criteria/awaiting_integration/postissue.sh
@@ -8,9 +8,8 @@ ${basereq} --action removeLabels \
     --issue ${issue} \
     --labels "cime"
 
-# Add the comment with results.
-# (Eloy 20131223 - restricted to Integrators)
-comment=$(cat "${resultfile}.${issue}.txt")
-${basereq} --action addComment \
+# Update the pre-check field with the results.
+${basereq} --action setFieldValue \
     --issue ${issue} \
-    --comment "${comment}"
+    --field "Pre-check results" \
+    --file "${resultfile}.${issue}.txt"

--- a/tracker_automations/bulk_precheck_issues/criteria/awaiting_peer_review/postissue.sh
+++ b/tracker_automations/bulk_precheck_issues/criteria/awaiting_peer_review/postissue.sh
@@ -8,8 +8,8 @@ ${basereq} --action removeLabels \
     --issue ${issue} \
     --labels "cime"
 
-# Add the comment with results
-comment=$(cat "${resultfile}.${issue}.txt")
-${basereq} --action addComment \
+# Update the pre-check field with the results.
+${basereq} --action setFieldValue \
     --issue ${issue} \
-    --comment "${comment}"
+    --field "Pre-check results" \
+    --file "${resultfile}.${issue}.txt"

--- a/tracker_automations/bulk_precheck_issues/criteria/developer_request/postissue.sh
+++ b/tracker_automations/bulk_precheck_issues/criteria/developer_request/postissue.sh
@@ -3,8 +3,8 @@ ${basereq} --action removeLabels \
     --issue ${issue} \
     --labels "cime CIME Cime CiMe" # the uppercase to fix MDLSITE-4716 and cases like MDL-64431
 
-# Add the comment with results
-comment=$(cat "${resultfile}.${issue}.txt")
-${basereq} --action addComment \
+# Update the pre-check field with the results.
+${basereq} --action setFieldValue \
     --issue ${issue} \
-    --comment "${comment}"
+    --field "Pre-check results" \
+    --file "${resultfile}.${issue}.txt"

--- a/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
@@ -131,7 +131,7 @@ while read issue; do
                     echo "    - Build: ${build}"
                     echo "    - URL: ${joburl}"
                     echo "    - Result: ${type}: ${joburl}"
-                    echo "  - ${type}: ${joburl}" >> "${resultfile}.${issue}.txt"
+                    echo "  - ${joburl} ${type}" >> "${resultfile}.${issue}.txt"
                 fi
             done < "${resultfile}.jenkinscli"
             echo "" >> "${resultfile}.${issue}.txt"

--- a/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
@@ -15,8 +15,6 @@
 #schedulemins: Frecuency (in minutes) of the schedule (cron) of this job. IMPORTANT to ensure that they match or there will be issues processed more than once or skipped.
 #jobtype: defaulting to "all", allows to just pick one of the available jobs: phpunit, behat-(firefox|chrome|nonjs|all).
 #quiet: with any value different from "false", don't perform any action in the Tracker.
-#restrictedto: name of the project (MDL) role we want to restrict the comment to. Blank means no restriction.
-
 
 # Let's go strict (exit on error)
 set -e
@@ -150,12 +148,7 @@ while read issue; do
 
     # Execute the criteria postissue. It will perform the needed changes in the tracker for the current issue
     if [[ ${quiet} == "false" ]]; then
-        # Let's see if there is any restriction to the comment in the Tracker
-        restrictiontype=
-        if [[ -n "${restrictedto}" ]]; then
-            restrictiontype=--role
-        fi
-        echo "  - Sending results to the Tracker (${restrictiontype} ${restrictedto})"
+        echo "  - Sending results to the Tracker"
         . "${mydir}/criteria/${criteria}/postissue.sh"
     fi
 done < "${resultfile}"

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_component_lead_review/postissue.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_component_lead_review/postissue.sh
@@ -1,10 +1,5 @@
-# Add the comment with results.
-if [[ -n "${restrictedto}" ]]; then
-    ${basereq} --action addComment \
-        --issue ${issue} \
-        --file "${resultfile}.${issue}.txt" ${restrictiontype} "${restrictedto}"
-else
-    ${basereq} --action addComment \
-        --issue ${issue} \
-        --file "${resultfile}.${issue}.txt"
-fi
+# Update the automated testing field with the results.
+${basereq} --action setFieldValue \
+    --issue ${issue} \
+    --field "Automated test results" \
+    --file "${resultfile}.${issue}.txt"

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_component_lead_review/query.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_component_lead_review/query.sh
@@ -2,7 +2,6 @@ ${basereq} --action getIssueList \
            --jql "project = 'Moodle' \
                  AND status = 'Waiting for component lead review' \
                  AND status WAS NOT 'Waiting for component lead review' ON '-${schedulemins}' \
-                 AND issue NOT IN commentedByUser('tobic') \
                  AND level IS EMPTY \
                  ORDER BY priority DESC, votes DESC, 'Last comment date' ASC" \
            --outputFormat 101 \

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/postissue.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/postissue.sh
@@ -1,10 +1,5 @@
-# Add the comment with results.
-if [[ -n "${restrictedto}" ]]; then
-    ${basereq} --action addComment \
-        --issue ${issue} \
-        --file "${resultfile}.${issue}.txt" ${restrictiontype} "${restrictedto}"
-else
-    ${basereq} --action addComment \
-        --issue ${issue} \
-        --file "${resultfile}.${issue}.txt"
-fi
+# Update the automated testing field with the results.
+${basereq} --action setFieldValue \
+    --issue ${issue} \
+    --field "Automated test results" \
+    --file "${resultfile}.${issue}.txt"

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/query.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/query.sh
@@ -2,7 +2,6 @@ ${basereq} --action getIssueList \
            --jql "project = 'Moodle' \
                  AND status = 'Waiting for integration review' \
                  AND status WAS NOT 'Waiting for integration review' ON '-${schedulemins}' \
-                 AND issue NOT IN commentedByUser('tobic') \
                  AND level IS EMPTY \
                  ORDER BY priority DESC, votes DESC, 'Last comment date' ASC" \
            --outputFormat 101 \

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls_sdev/postissue.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls_sdev/postissue.sh
@@ -1,10 +1,5 @@
-# Add the comment with results.
-if [[ -n "${restrictedto}" ]]; then
-    ${basereq} --action addComment \
-        --issue ${issue} \
-        --file "${resultfile}.${issue}.txt" ${restrictiontype} "${restrictedto}"
-else
-    ${basereq} --action addComment \
-        --issue ${issue} \
-        --file "${resultfile}.${issue}.txt"
-fi
+# Update the automated testing field with the results.
+${basereq} --action setFieldValue \
+    --issue ${issue} \
+    --field "Automated test results" \
+    --file "${resultfile}.${issue}.txt"

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/multi_database/postissue.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/multi_database/postissue.sh
@@ -1,10 +1,5 @@
-# Add the comment with results.
-if [[ -n "${restrictedto}" ]]; then
-    ${basereq} --action addComment \
-        --issue ${issue} \
-        --file "${resultfile}.${issue}.txt" ${restrictiontype} "${restrictedto}"
-else
-    ${basereq} --action addComment \
-        --issue ${issue} \
-        --file "${resultfile}.${issue}.txt"
-fi
+# Update the automated testing field with the results.
+${basereq} --action setFieldValue \
+    --issue ${issue} \
+    --field "Automated test results" \
+    --file "${resultfile}.${issue}.txt"


### PR DESCRIPTION
* CiBoT results will be posted in the "Pre-check results" field.
* ToBiC results from the `bulk_prelaunch_jobs` will be posted in the "Automated test results" field.
* The positions of the job URL and the job description have been switched.