### PR TITLE
Acknowledge thirdpartylibs.xml in plugin names with 'work'

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -456,7 +456,7 @@ echo "Info: Deleting excluded and unrelated files..."
 # Remove all the excluded (but .git and work)
 set -e
 for todelete in ${excluded}; do
-    if [[ ${todelete} =~ ".git" || ${todelete} =~ "work" || ${todelete} =~ "node_modules" ]]; then
+    if [[ ${todelete} =~ ".git" || ${todelete} =~ ^work/ || ${todelete} =~ "node_modules" ]]; then
         continue
     fi
     rm -fr "${WORKSPACE}/${todelete}"


### PR DESCRIPTION
When removing files irrelevant to the tests, any files or folders containing the substring "work" remain untouched. This poses a problem if the plugin uses that substring.

See https://tracker.moodle.org/browse/MDLSITE-7849 for more details.