### PR TITLE
Check automated test results field is empty before launching new builds

### DIFF
--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_component_lead_review/query.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_component_lead_review/query.sh
@@ -3,6 +3,7 @@ ${basereq} --action getIssueList \
                  AND status = 'Waiting for component lead review' \
                  AND status WAS NOT 'Waiting for component lead review' ON '-${schedulemins}' \
                  AND level IS EMPTY \
+                 AND 'Automated test results' IS EMPTY \
                  ORDER BY priority DESC, votes DESC, 'Last comment date' ASC" \
            --outputFormat 101 \
            --file "${resultfile}"

--- a/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/query.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/awaiting_integration/query.sh
@@ -3,6 +3,7 @@ ${basereq} --action getIssueList \
                  AND status = 'Waiting for integration review' \
                  AND status WAS NOT 'Waiting for integration review' ON '-${schedulemins}' \
                  AND level IS EMPTY \
+                 AND 'Automated test results' IS EMPTY \
                  ORDER BY priority DESC, votes DESC, 'Last comment date' ASC" \
            --outputFormat 101 \
            --file "${resultfile}"

--- a/tracker_automations/mv_reopened_out_from_current/mv_reopened_out_from_current.sh
+++ b/tracker_automations/mv_reopened_out_from_current/mv_reopened_out_from_current.sh
@@ -74,11 +74,15 @@ while read line; do
     #    --issue ${issue} \
     #    --field "customfield_10211=" \
     #    --comment "Moving this reopened issue out from current integration. Please, re-submit it for integration once ready."
+    #
+    # Note: customfield_10211 represents the "Currently in integration" field, and customfield_17112 represents
+    # the "Automated test results" field.
     ${basereq} --action transitionIssue \
         --issue ${issue} \
         --transition "CI Global Self-Transition" \
         --fixVersions "${keepversion}" \
         --field "customfield_10211=" \
+        --field "customfield_17112=" \
         --comment "Moving this reopened issue out from current integration. Please, re-submit it for integration once ready."
     echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue}" >> "${logfile}"
 done < "${resultfile}"


### PR DESCRIPTION
This commit changes the waititing for IR and CLR automations to check if the 'Automated test results' field is empty before launching a new build. It also changes the reopened automation to clear that field, so next time the issue is sent to IR, a new CI build will be launched.

