### PR TITLE
Use the correct automated test results fieldname

### DIFF
--- a/tracker_automations/mv_reopened_out_from_current/mv_reopened_out_from_current.sh
+++ b/tracker_automations/mv_reopened_out_from_current/mv_reopened_out_from_current.sh
@@ -75,14 +75,14 @@ while read line; do
     #    --field "customfield_10211=" \
     #    --comment "Moving this reopened issue out from current integration. Please, re-submit it for integration once ready."
     #
-    # Note: customfield_10211 represents the "Currently in integration" field, and customfield_17112 represents
+    # Note: customfield_10211 represents the "Currently in integration" field, and customfield_17112-val represents
     # the "Automated test results" field.
     ${basereq} --action transitionIssue \
         --issue ${issue} \
         --transition "CI Global Self-Transition" \
         --fixVersions "${keepversion}" \
         --field "customfield_10211=" \
-        --field "customfield_17112=" \
+        --field "customfield_17112-val=" \
         --comment "Moving this reopened issue out from current integration. Please, re-submit it for integration once ready."
     echo "$BUILD_NUMBER $BUILD_TIMESTAMP ${issue}" >> "${logfile}"
 done < "${resultfile}"


### PR DESCRIPTION
This commit changes the script to use customfield_17112-val as the "Automated test results" field