### PR TITLE
Use proper field separator for parsing available CLRs

### DIFF
--- a/tracker_automations/component_leads_integration_mover/lib.sh
+++ b/tracker_automations/component_leads_integration_mover/lib.sh
@@ -172,14 +172,14 @@ function verify_revievers_availability() {
         return # Outcome set, we are done.
     fi
 
-    # There is some component lead reviewer available, let's send the issue to CLR. This check is done.
+    # There is at least one component lead reviewer available, let's send the issue to CLR. This check is done.
     echo "      - There are available reviewers (${available}) for the issue."
     outcome=CLR
     availableProfiles=()
-    IFS=, read -r -a availableCLRs <<<"$available"
+    IFS=' ' read -r -a availableCLRs <<<"$available"
     for availableCLR in "${availableCLRs[@]}"; do
         availableCLR=$(trimstring "$availableCLR")
-        if [[ -z ${available} ]]; then
+        if [[ -z ${availableCLR} ]]; then
             continue
         fi
         availableProfiles+=("[~${availableCLR}]")


### PR DESCRIPTION
The list of available CLRers in the `$available` variable are space-separated. So the internal field separator should be set to space instead of comma.

Plus, there is a minor fix for empty-checking the `$availableCLR`.

To test this fix:
1. Clone the repo.
2. Include `tracker_automations/component_leads_integration_mover/lib.sh`. (We just want to include the `trimstring()` function.)
```bash
source path/to/tracker_automations/component_leads_integration_mover/lib.sh
```
3.  Copy and paste the following script:
```bash
available="amaia tusefomal"
# This is the code snippet containing the fix.
availableProfiles=()
IFS=' ' read -r -a availableCLRs <<<"$available"
for availableCLR in "${availableCLRs[@]}"; do
    availableCLR=$(trimstring "$availableCLR")
    if [[ -z ${availableCLR} ]]; then
        continue
    fi
    availableProfiles+=("[~${availableCLR}]")
done
outcomedesc=$(IFS=, ; echo "Sending to CLR, there are available reviewers for the issue: ${availableProfiles[*]}")
# Check the value for outcomedesc.
echo $outcomedesc
```
4. Confirm you see `Sending to CLR, there are available reviewers for the issue: [~amaia],[~tusefomal]`