### PR TITLE
Support shortentext helper

### DIFF
--- a/mustache_lint/mustache_lint.php
+++ b/mustache_lint/mustache_lint.php
@@ -117,6 +117,12 @@ $mustache = new Mustache_Engine([
             $content = preg_replace('([{}]{2,3})', '{{=<% %>=}}${0}<%={{ }}=%>', $content);
             return '"' . $content . '"';
         },
+        'shortentext' => function ($text) {
+            [$length, $content] = explode(',', $text, 2);
+            $length = intval(trim($length));
+            $content = trim($content);
+            return substr($content, 0, $length) . (strlen($content > $length) ? '...' : '');
+        },
         'js' => [$jshelper, 'add_js'],
     ],
     'partials_loader' => new simple_core_component_mustache_loader($theme),


### PR DESCRIPTION
Mustache Lint is missing support for shortentext helper. This produces some misleading errors.

This patch adds support for an emulated helper.