### PR TITLE
Limit line length in commit message body to 72 characters

### DIFF
--- a/tests/verify_commit_messages.bats
+++ b/tests/verify_commit_messages.bats
@@ -90,7 +90,7 @@ commit_apply_fixture_and_run() {
 @test "verify_commit_messages/verify_commit_messages.sh: body too long" {
     commit_apply_fixture_and_run too-long-body.patch
     assert_failure
-    assert_output "${shorthash}*error*The line #3 has more than 132 characters (found: 181)"
+    assert_output "${shorthash}*error*The line #3 has more than 72 characters (found: 181)"
 }
 
 @test "verify_commit_messages/verify_commit_messages.sh: backslash ended lines" {
@@ -98,7 +98,7 @@ commit_apply_fixture_and_run() {
     assert_failure
     refute_output "#3"
     refute_output "#5"
-    assert_output "${shorthash}*error*The line #7 has more than 132 characters (found: 141)"
+    assert_output "${shorthash}*error*The line #7 has more than 72 characters (found: 141)"
 }
 
 @test "verify_commit_messages/verify_commit_messages.sh: AMOS bad syntax" {

--- a/verify_commit_messages/verify_commit_messages.sh
+++ b/verify_commit_messages/verify_commit_messages.sh
@@ -18,7 +18,7 @@
 #   COMMIT (short) * LEVEL (error or warning) * DESCRIPTION (details)
 # Example:
 #   1234abcd*error*Commit messages does not start with issue code.
-#   2345bcde*warning*Body line too long (184 > 132).
+#   2345bcde*warning*Body line too long (184 > 72).
 #   2345cdef*error*Subject line too long (75 > 72).
 
 # Don't be strict. Script has own error control handle
@@ -200,10 +200,10 @@ for c in ${commits}; do
                 fi
             # check rest of lines
             else
-                # verify 3rd and following lines are <= 132 chars long. Warn.
+                # verify 3rd and following lines are <= 72 chars long. Warn.
                 len=$(echo "${line}" | wc -c)
-                if [[ ${len} -gt 132 ]]; then
-                    echo "${c}*error*The line #${currentline} has more than 132 characters (found: ${len})"
+                if [[ ${len} -gt 72 ]]; then
+                    echo "${c}*error*The line #${currentline} has more than 72 characters (found: ${len})"
                     numproblems=$((numproblems+1))
                 fi
             fi


### PR DESCRIPTION
Following a discussion in Moodle Dev chat and the recommendation from the Commit cheat sheet the commit message body should wrap at 72 and not at 132 characters.