### PR TITLE
Report list of modified upgrade.txt or UPGRADING.md files

### DIFF
--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -318,11 +318,12 @@ sed '/^$/d' ${WORKSPACE}/work/patchset.files > ${WORKSPACE}/work/patchset.files.
 mv ${WORKSPACE}/work/patchset.files.tmp ${WORKSPACE}/work/patchset.files
 
 # For 4.5 and up, verify that the we aren't modifying any upgrade.txt or UPGRADING.md files.
+# lib/guzzlehttp/guzzle/UPGRADING.md is a false positive. It's a vendored file.
 if [[ ${versionbranch} -ge 405 ]]; then
-    if grep -q 'UPGRADING.md\|upgrade.txt' ${WORKSPACE}/work/patchset.files; then
+    if sed '/lib\/guzzlehttp\/guzzle\/UPGRADING.md/d' ${WORKSPACE}/work/patchset.files | grep -q 'UPGRADING.md\|upgrade.txt'; then
         echo "Error: The patchset contains changes to upgrade.txt or UPGRADING.md files." | tee -a ${errorfile}
 
-        dirtyupgrades="$( grep 'UPGRADING.md\|upgrade.txt' ${WORKSPACE}/work/patchset.files )"
+        dirtyupgrades="$( sed '/lib\/guzzlehttp\/guzzle\/UPGRADING.md/d' ${WORKSPACE}/work/patchset.files | grep 'UPGRADING.md\|upgrade.txt' )"
         if [[ -n "${dirtyupgrades}" ]]; then
             echo "Error: File(s) affected:" | tee -a ${errorfile}
             echo "${dirtyupgrades}" | sed "/^${WORKSPACE}//g" | sed 's/^/Error: /' | tee -a ${errorfile}

--- a/remote_branch_checker/remote_branch_checker.sh
+++ b/remote_branch_checker/remote_branch_checker.sh
@@ -321,6 +321,12 @@ mv ${WORKSPACE}/work/patchset.files.tmp ${WORKSPACE}/work/patchset.files
 if [[ ${versionbranch} -ge 405 ]]; then
     if grep -q 'UPGRADING.md\|upgrade.txt' ${WORKSPACE}/work/patchset.files; then
         echo "Error: The patchset contains changes to upgrade.txt or UPGRADING.md files." | tee -a ${errorfile}
+
+        dirtyupgrades="$( grep 'UPGRADING.md\|upgrade.txt' ${WORKSPACE}/work/patchset.files )"
+        if [[ -n "${dirtyupgrades}" ]]; then
+            echo "Error: File(s) affected:" | tee -a ${errorfile}
+            echo "${dirtyupgrades}" | sed "/^${WORKSPACE}//g" | sed 's/^/Error: /' | tee -a ${errorfile}
+        fi
     fi
 fi
 

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_txt_for_405.regex
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_txt_for_405.regex
@@ -5,3 +5,8 @@
 condensedresult="smurf,error,1,0:overview,error,1,0
 <detail name="overview" status="error" numerrors="1" numwarnings="0"/>
 <message>The patchset contains changes to upgrade.txt or UPGRADING.md files.</message>
+<message>File(s) affected:</message>
+<message>UPGRADING.md</message>
+<message>lib/upgrade.txt</message>
+<message>mod/assign/UPGRADING.md</message>
+<message>mod/assign/upgrade.txt</message>


### PR DESCRIPTION
When we experience modifications in any upgrade.txt or UPGRADING.md files it would be nice to have more information what files are affected.

We would also need a modification in file `lib/guzzlehttp/guzzle/UPGRADING.md` on the branch `local_ci_fixture_upgrade_txt_for_405` for the tests to succeed.