### PR TITLE
Use Ubuntu 22.04 for code coverage tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,8 @@ jobs:
     if: github.repository == 'moodlehq/moodle-local_ci'
     name: Code coverage
     needs: collect
-    runs-on: ubuntu-latest
+    # Ubuntu 24.04 is missing the kcov package. We can switch back to ubuntu-latest, once it points to 26.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Ubuntu 24.04 is missing the kcov package. We can switch back to ubuntu-latest, once it points to Ubuntu 26.04

Fixes: #327