### PR TITLE
Handling of issues for the CLR queue during the code freeze period.

### DIFF
--- a/tracker_automations/continuous_manage_queues/lib.sh
+++ b/tracker_automations/continuous_manage_queues/lib.sh
@@ -19,12 +19,12 @@ function run_A1() {
     # Note this could be done by one unique "runFromIssueList" action, but we are splitting
     # the search and the update in order to log all the closed issues within jenkins ($logfile)
 
-    # Basically get all the issues in the candidates queues (filter=14000 OR filter=23329), that are not bug
+    # Basically get all the issues in the candidates queues (filter=14000), that are not bug
     # and that haven't received any comment with the standard unholding text (NOT filter = 22054)
 
     # Get the list of issues.
     ${basereq} --action getIssueList \
-               --jql "(filter=14000 OR filter=23329) \
+               --jql "(filter=14000) \
                      AND type IN ('New Feature', Improvement) \
                      AND NOT filter = 22054" \
                --file "${resultfile}"


### PR DESCRIPTION
* Update the `Manage queues on continuous job` so that improvements and new features in the CLR queue will not be held during the freeze period until the last week before the release (behaviour A1).

Note: Keeping the behaviour for
- A3b (last week before release, all issues unrelated to the release will be held)
- B1a (during the on-sync period, only bugs will be integrated)

* During the freeze, improvements and new features will be excluded from being triaged for the CLR queue so that they will remain in the candidate queue and be held accordingly.