### PR TITLE
Explicit date format for build date in tracker automations.

### DIFF
--- a/tracker_automations/bulk_precheck_issues/bulk_precheck_issues.sh
+++ b/tracker_automations/bulk_precheck_issues/bulk_precheck_issues.sh
@@ -293,9 +293,10 @@ while read issue; do
     else
         echo "[Should these errors be fixed?|https://moodledev.io/general/development/tools/cibot#should-coding-style-issues-in-existing-code-be-fixed]" >> "${resultfile}.${issue}.txt"
     fi
+
     # Add build timestamp to the bottom of the report
     echo "" >> "${resultfile}.${issue}.txt"
-    echo "Built on: $(date -u)" >> "${resultfile}.${issue}.txt"
+    echo "Built on: $(date -u '+%a %b %e %H:%M:%S %Z %Y')" >> "${resultfile}.${issue}.txt"
 
     # Execute the criteria postissue. It will perform the needed changes in the tracker for the current issue
     if [[ ${quiet} == "false" ]]; then

--- a/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
@@ -138,7 +138,9 @@ while read issue; do
             rm "${resultfile}.jenkinscli"
         fi
     done
-    echo "Built on: $(date -u)" >> "${resultfile}.${issue}.txt"
+
+    # Add build timestamp to the bottom of the report
+    echo "Built on: $(date -u '+%a %b %e %H:%M:%S %Z %Y')" >> "${resultfile}.${issue}.txt"
 
     echo ""
     # Verify we have processed some branch.


### PR DESCRIPTION
The date format used for each of the "Pre-check results" and "Automated test results" tracker fields differs in a confusing way:

![Screenshot 2025-02-26 at 18-23-09 MDL-84384 Improve AI usage report filtering for provider_action data - Moodle Tracker](https://github.com/user-attachments/assets/0e9f88e8-e68e-4427-a5dc-cc11adbd6065)

The chosen format is as described here, and matches the latter of the two fields above: https://unix.stackexchange.com/a/687874