### PR TITLE
Use ubuntu jammy for tests that require kcov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
     if: github.repository == 'moodlehq/moodle-local_ci'
     name: Code coverage
     needs: collect
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
With the `ubuntu-latest` now using `noble numbat`, the `kcov` package seems no longer available, so tests that require it are now failing. I'm not sure what the alternate would be, but pinning runs that require `kcov` to use ubuntu-jammy may be a quick fix until we find more time to look into it.