### PR TITLE
Avoid holding issues just bumped from CLR to integration

### DIFF
--- a/tracker_automations/continuous_manage_queues/lib.sh
+++ b/tracker_automations/continuous_manage_queues/lib.sh
@@ -21,12 +21,14 @@ function run_A1() {
 
     # Basically get all the issues in the candidates queues (filter=14000), that are not bug
     # and that haven't received any comment with the standard unholding text (NOT filter = 22054)
+    # excluding issues recently bumped from CLR back to integration
 
     # Get the list of issues.
     ${basereq} --action getIssueList \
                --jql "(filter=14000) \
                      AND type IN ('New Feature', Improvement) \
-                     AND NOT filter = 22054" \
+                     AND NOT filter = 22054 \
+                     AND NOT (status changed FROM 'Waiting for component lead review' TO 'Waiting for integration review' AFTER -2h)" \
                --file "${resultfile}"
 
     # Iterate over found issues and perform the actions with them.


### PR DESCRIPTION
This should prevent issues being integration held if they were simply bumped from CLR back to integration during the freeze. It appears the task is run half hourly, so I set a 2 hour buffer just to cover any cases where it's delayed/doesn't run for some reason.

This is my first contribution to this repo, so please let me know if anything else is required (eg specific testing requirements).