### PR TITLE
Prevent incorrect holds

### DIFF
--- a/tracker_automations/continuous_manage_queues/lib.sh
+++ b/tracker_automations/continuous_manage_queues/lib.sh
@@ -184,16 +184,17 @@ function run_A3a() {
 
 # A3b, add the "integration_held" + standard comment to any issue arriving to candidates (IR & CLR).
 function run_A3b() {
-    # Get the list of issues in the candidates queues (IR & CLR). All them will be held with last week comment.
+    # Get the list of issues in the candidates queues (IR & CLR) and hold with the last week comment, if necessary.
+    # All issues in CLR that don't belong to any criteria below will be held:
+    # - Must-fix issues
+    # - mdlqa issues
     ${basereq} --action getIssueList \
-               --jql "filter=14000 OR
-                  (
-                    filter=23329
-                    AND NOT (
-                      filter = 21363 OR
-                      labels IN (mdlqa)
-                    )
-                  )" \
+               --jql "filter=14000 OR (
+                      filter=23329 AND NOT (
+                        filter = 21363 OR
+                        labels IN (mdlqa)
+                      )
+                    )" \
                --file "${resultfile}"
 
     # Iterate over found issues, moving them to the current queue.

--- a/tracker_automations/continuous_manage_queues/lib.sh
+++ b/tracker_automations/continuous_manage_queues/lib.sh
@@ -62,7 +62,8 @@ function run_A2() {
                      AND NOT filter = 21366
                      AND (
                        filter = 21363 OR
-                       labels IN (mdlqa)
+                       labels IN (mdlqa) OR
+                       level IS NOT EMPTY
                      )" \
                --file "${resultfile}"
 

--- a/tracker_automations/continuous_manage_queues/lib.sh
+++ b/tracker_automations/continuous_manage_queues/lib.sh
@@ -186,7 +186,14 @@ function run_A3a() {
 function run_A3b() {
     # Get the list of issues in the candidates queues (IR & CLR). All them will be held with last week comment.
     ${basereq} --action getIssueList \
-               --jql "filter=14000 OR filter=23329" \
+               --jql "filter=14000 OR
+                  (
+                    filter=23329
+                    AND NOT (
+                      filter = 21363 OR
+                      labels IN (mdlqa)
+                    )
+                  )" \
                --file "${resultfile}"
 
     # Iterate over found issues, moving them to the current queue.


### PR DESCRIPTION
This PR addresses two issues:
- Because security issues are not treated as "important," they are not automatically moved to the current queue. Thus, they get held, especially during the last week before the release, which is incorrect because security issues are considered related to the release. We must again treat security issues in the continuous queues manager as important.
- Must-fix and `mdlqa` issues in CLR are being incorrectly held because the query in `run_A3b` for the CLR part (`filter=23329`) does not exclude must-fix and `mdlqa` issues from being held for issues in the CLR queue.