### PR TITLE
Allow AMOS to perform git commands

### DIFF
--- a/verify_commit_messages/verify_commit_messages.sh
+++ b/verify_commit_messages/verify_commit_messages.sh
@@ -129,7 +129,7 @@ for c in ${commits}; do
     else
         # Run AMOS checks.
         modifiedfiles=$(git diff-tree --no-commit-id --name-only -r ${c} | tr '\n' ',')
-        echo "$message" | $phpcmd $mydir/check_amos.php --commitid=${c} --filesmodified=$modifiedfiles
+        $phpcmd $mydir/check_amos.php --git="${gitcmd}" --commitid=${c}
 
         numproblems=$((numproblems+$?))
 


### PR DESCRIPTION
This prevent issues when passing a large number of changes files to the amos script.

Previously the git commands were run in the shell script and values passed to the php script, but where there are large numbers of files this breaks because PHP hits ARG limits.

This issue has come about because I'm hitting these limits in MDL-83424