### PR TITLE
Ignore renamed files for mustache lint

### DIFF
--- a/list_changed_files/list_changed_files.sh
+++ b/list_changed_files/list_changed_files.sh
@@ -10,6 +10,8 @@
 # Don't be strict. Script has own error control handle
 set +e
 
+difffilter=${1:-"ACDMRTUXB"}
+
 # Verify everything is set
 required="gitcmd gitdir initialcommit finalcommit"
 for var in $required; do
@@ -46,5 +48,5 @@ if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
 fi
 
 # get all the files changed between both commits (no matter the diffs are empty)
-git log --name-only --pretty=oneline --full-index ${initialcommit}..${finalcommit} | \
+git log --diff-filter=${difffilter} --find-renames=100% --name-only --pretty=oneline --full-index ${initialcommit}..${finalcommit} | \
     grep -vE '^[0-9a-f]{40} ' | sort | uniq

--- a/mustache_lint/mustache_lint.sh
+++ b/mustache_lint/mustache_lint.sh
@@ -46,7 +46,9 @@ echo "Validating using $validator"
 
 export initialcommit=${GIT_PREVIOUS_COMMIT}
 export finalcommit=${GIT_COMMIT}
-if mfiles=$(${mydir}/../list_changed_files/list_changed_files.sh)
+# Fetch all files, excluding files which are renames.
+# There is no need to check renames.
+if mfiles=$(${mydir}/../list_changed_files/list_changed_files.sh r)
 then
     echo "Running mustache lint from $initialcommit to $finalcommit:"
 else


### PR DESCRIPTION
If files are only renamed, and do not contain any other changes, there is not need to mustache lint them.

This issue has come about because we're renaming all of the mustache templates in MDL-83424 and it's timing out the job.