### PR TITLE
Fix broken unit test

### DIFF
--- a/tests/verify_phpunit_xml.bats
+++ b/tests/verify_phpunit_xml.bats
@@ -32,7 +32,7 @@ teardown () {
     assert_success
     assert_output --partial "OK: competency/tests will be executed"
     assert_output --partial "INFO: backup/util/ui/tests will be executed because the backup/util definition"
-    assert_output --partial "INFO: Ignoring privacy/classes/tests, it does not contain any test unit file."
+    assert_output --partial "INFO: Ignoring theme/boost/scss/bootstrap/tests, it does not contain any test unit file."
     refute_output --partial "WARNING"
     refute_output --partial "ERROR"
 }


### PR DESCRIPTION
The phpunit unit test was assuming that the privacy subsystem had no tests. This was failing because there are tests.

Changing to a component which (currently) has no tests.