### PR TITLE
Separate pre-checker coloured text from link content.

### DIFF
--- a/tracker_automations/bulk_precheck_issues/bulk_precheck_issues.sh
+++ b/tracker_automations/bulk_precheck_issues/bulk_precheck_issues.sh
@@ -202,7 +202,7 @@ while read issue; do
                         elif [[ ${testresult} == "error" ]]; then
                             testcolor="red"
                         fi
-                        details="${details} [{color:${testcolor}}${testname} (${errors}/${warnings}){color}|${joburl}/artifact/work/smurf.html#${testname}],"
+                        details="${details} {color:${testcolor}}${testname}{color} [(${errors}/${warnings})|${joburl}/artifact/work/smurf.html#${testname}],"
                     fi
                     if [[ "${detailslist}" == "${detail}" ]]; then
                         detailslist=''


### PR DESCRIPTION
Restores the previous lost styling to indicate pass/warn/error details as reported at https://moodle.atlassian.net/browse/ICT-5408