### PR TITLE
Re-format the job badge/URL display in automated results.

### DIFF
--- a/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/bulk_prelaunch_jobs.sh
@@ -136,7 +136,7 @@ while read issue; do
                     echo "    - Build: ${build}"
                     echo "    - URL: ${joburl}"
                     echo "    - Result: ${type}: ${joburl}"
-                    echo "  - [!${badgeurl}!|${joburl}] ${type}" >> "${resultfile}.${issue}.txt"
+                    echo "|!${badgeurl}|width=96,height=20!|[${type}|${joburl}]|" >> "${resultfile}.${issue}.txt"
                 fi
             done < "${resultfile}.jenkinscli"
             echo "" >> "${resultfile}.${issue}.txt"


### PR DESCRIPTION
Follows 9f5bc544, and works around current Jira limitation in image hyperlinks and sizing, from original https://github.com/moodlehq/moodle-local_ci/pull/352