### PR TITLE
Tag CLRs by AccountIDs

### DIFF
--- a/tracker_automations/component_leads_integration_mover/lib.sh
+++ b/tracker_automations/component_leads_integration_mover/lib.sh
@@ -182,7 +182,14 @@ function verify_revievers_availability() {
         if [[ -z ${availableCLR} ]]; then
             continue
         fi
-        availableProfiles+=("[~${availableCLR}]")
+        # Due to GDPR, we cannot mention the email address of the reviewer, so we need to get the accountID.
+        # File where accountID will be stored.
+        accountfile=${WORKSPACE}/component_leads_integration_mover_accountid.txt
+        echo -n > "${accountfile}"
+        ${basereq} --action getUser --userEmail ${availableCLR} --quiet --file "${accountfile}" > /dev/null
+        CLRAccountID=$(cat "${accountfile}")
+        rm "${accountfile}"
+        availableProfiles+=("[~${CLRAccountID}]")
     done
     outcomedesc=$(IFS=, ; echo "Sending to CLR, there are available reviewers for the issue: ${availableProfiles[*]}")
     return # Outcome set, and function finished we are done.


### PR DESCRIPTION
Jira Cloud does not support mentioning users directly by email address due to privacy and GDPR-related restrictions. Instead, we need to mention users using their accountId.