### PR TITLE
Tag CLRs by AccountIDs using API

### DIFF
--- a/jira.sh
+++ b/jira.sh
@@ -35,3 +35,7 @@ done
 
 # Set the base request command.
 basereq="${jiraclicmd} --server ${jiraserver} --user ${jirauser} --password ${jirapass}"
+# Set the base API request command.
+# Remove trailing slash from jiraserver if present
+jiraserver_clean="${jiraserver%/}"
+baseapireq="${jiraserver_clean}/rest/api/3/"

--- a/tracker_automations/component_leads_integration_mover/lib.sh
+++ b/tracker_automations/component_leads_integration_mover/lib.sh
@@ -186,10 +186,11 @@ function verify_revievers_availability() {
         # File where accountID will be stored.
         accountfile=${WORKSPACE}/component_leads_integration_mover_accountid.txt
         echo -n > "${accountfile}"
-        ${basereq} --action getUser --userEmail ${availableCLR} --quiet --file "${accountfile}" > /dev/null
-        CLRAccountID=$(cat "${accountfile}")
+        curl -u ${jirauser}:${jirapass} \
+          -X GET "${baseapireq}user/search?query=${availableCLR}" > "${accountfile}"
+        CLRAccountID=$(grep -o '"accountId":"[^"]*"' "${accountfile}" | head -n1 | sed 's/"accountId":"\([^"]*\)"/\1/')
         rm "${accountfile}"
-        availableProfiles+=("[~${CLRAccountID}]")
+        availableProfiles+=("[~accountId:${CLRAccountID}]")
     done
     outcomedesc=$(IFS=, ; echo "Sending to CLR, there are available reviewers for the issue: ${availableProfiles[*]}")
     return # Outcome set, and function finished we are done.


### PR DESCRIPTION
Switch to use Rest API because JiraCLI of Cloud does not return the accountId