### PR TITLE
Support public directory for checks (MDL-83424)

### DIFF
--- a/list_valid_components/list_valid_components.sh
+++ b/list_valid_components/list_valid_components.sh
@@ -24,10 +24,19 @@ done
 # calculate some variables
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+if [[ -d "${gitdir}/public" || -f "${gitdir}/public/version.php" ]]; then
+    # If we have public directory, then use it as rootdir
+    rootdir="${gitdir}/public"
+    echo "+ INFO: Using public directory as rootdir: ${rootdir}"
+else
+    rootdir="${gitdir}"
+    echo "+ INFO: Using gitdir as rootdir: ${gitdir}"
+fi
+
 # Since Moodle 2.6 we don't need to install the moodle site nor copy the php script to it.
-if [[ -f "${gitdir}/lib/classes/component.php" ]]; then
+if [[ -f "${rootdir}/lib/classes/component.php" ]]; then
     cd ${mydir}
-    ${phpcmd} list_valid_components.php --basedir="${gitdir}" --absolute=true
+    ${phpcmd} list_valid_components.php --basedir="${rootdir}" --absolute=true
     exitstatus=${PIPESTATUS[0]}
     if [ $exitstatus -ne 0 ]; then
         echo "Problem executing the >= 2.6 alternative"

--- a/verify_phpunit_xml/create_phpunit_xml.php
+++ b/verify_phpunit_xml/create_phpunit_xml.php
@@ -79,22 +79,28 @@ if (!load_core_component_from_moodle($options['basedir'])) {
     cli_error('Something went wrong. Components not loaded from ' . $options['basedir']);
 }
 
+if (file_exists("{$options['basedir']}/public/version.php")) {
+    $dirroot = "{$options['basedir']}/public";
+} else {
+    $dirroot = $options['basedir'];
+}
+
 // We need to register the Moodle autoloader.
-require_once($options['basedir'] . '/lib/classes/component.php');
+require_once("{$dirroot}/lib/classes/component.php");
 spl_autoload_register([\core_component::class, 'classloader']);
 
 // Now, let's invoke phpunit utils to generate the phpunit.xml file
 
 // We need to load a few things manually.
-require_once($options['basedir'] . '/lib/phpunit/classes/util.php');
+require_once("{$dirroot}/lib/phpunit/classes/util.php");
 
 if (!class_exists(\core\output\core_renderer::class)) {
     // From Moodle 4.5 we start to autoload the output components and including outputcomponents.php will throw an exception.
     // If the core_renderer class can be autoloaded then we do not need to include outputcomponents.php.
-    require_once($options['basedir'] . '/lib/outputcomponents.php');
+    require_once("{$dirroot}/lib/outputcomponents.php");
 }
 
-require_once($options['basedir'] . '/lib/testing/lib.php');
+require_once("{$dirroot}/lib/testing/lib.php");
 phpunit_util::build_config_file();
 
 // We are done, end here.


### PR DESCRIPTION
This patchset:
* makes the `list_valid_components` tooling work with the new `public` directory;
* makes the `create_phpunit_xml.php` tooling work with the public directory; and
* makes the version check tooling work too.