### PR TITLE
Fix tests for verify_phpunit_xml after MDL-83424

### DIFF
--- a/tests/verify_phpunit_xml.bats
+++ b/tests/verify_phpunit_xml.bats
@@ -30,9 +30,9 @@ teardown () {
     ci_run verify_phpunit_xml/verify_phpunit_xml.sh
 
     assert_success
-    assert_output --partial "OK: competency/tests will be executed"
-    assert_output --partial "INFO: backup/util/ui/tests will be executed because the backup/util definition"
-    assert_output --partial "INFO: Ignoring theme/boost/scss/bootstrap/tests, it does not contain any test unit file."
+    assert_output --partial "OK: public/competency/tests will be executed"
+    assert_output --partial "INFO: public/backup/util/ui/tests will be executed because the public/backup/util definition"
+    assert_output --partial "INFO: Ignoring public/theme/boost/scss/bootstrap/tests, it does not contain any test unit file."
     refute_output --partial "WARNING"
     refute_output --partial "ERROR"
 }


### PR DESCRIPTION
Because of the move to public with the changes in [MDL-83424](https://moodle.atlassian.net/browse/MDL-83424), test 2, which runs on the main branch, needed some adjusting for the extra `public` at the beginning of the file paths.

[MDL-83424]: https://moodle.atlassian.net/browse/MDL-83424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ