### PR TITLE
Fix tests for remote_branch_checker after swichting to PSR-12 code styling

### DIFF
--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_phpcs_aware_components.regex
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_phpcs_aware_components.regex
@@ -2,7 +2,7 @@
 # that match the most relevant aspects of the test being executed
 # and its smurf.xml results.
 
-<detail name="phpcs" status="error" numerrors="2" numwarnings="1"/>
+<detail name="phpcs" status="error" numerrors="3" numwarnings="1"/>
 <description>This section shows the coding style problems detected in the code by phpcs</description>
 <problem file="mod/glossary/tests/lib_test.php"
 PHPUnit class namespace "mod_wrong" does not match expected file namespace "mod_glossary"

--- a/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_external_backup_skipped_for_plugins.regex
+++ b/tests/fixtures/remote_branch_checker/local_ci_fixture_upgrade_external_backup_skipped_for_plugins.regex
@@ -3,4 +3,4 @@
 # and its smurf.xml results.
 
 # Just verify that there isn't any externalbackup section in the report
-condensedresult="smurf,success,0,0:overview,success,0,0;phplint,success,0,0;phpcs,success,0,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0"
+condensedresult="smurf,error,1,0:overview,success,0,0;phplint,success,0,0;phpcs,error,1,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0"


### PR DESCRIPTION
As [MDLSITE-7597](https://moodle.atlassian.net/browse/MDLSITE-7597) has now landed and the code style regarding the wrapping of lines is now following the PSR-12 approach, we need to adjust some tests.

Test 8 (`local_ci_fixture_phpcs_aware_components`) of `remote_branch_checker` has now one error in the phpcs check because of the `Squiz` rulseset (`rule="WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"`)


```
[...]

#     <summary status="error" numerrors="1" numwarnings="0" condensedresult="smurf,error,1,0:overview,success,0,0;phplint,success,0,0;phpcs,error,1,0;js,success,0,0;css,success,0,0;phpdoc,success,0,0;savepoint,success,0,0;thirdparty,success,0,0;grunt,success,0,0;shifter,success,0,0;mustache,success,0,0;gherkin,success,0,0">

[...]


#     <check id="phpcs" title="PHP coding style problems" url="https://moodledev.io/general/development/policies/codingstyle" numerrors="1" numwarnings="0" allowfiltering="1">
#       <description>This section shows the coding style problems detected in the code by phpcs</description>
#       <mess>
#         <problem file="mod/forum/db/upgrade.php" linefrom="338" lineto="338" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/fb0e3aacb3036e0353aab727b86a186f8001a8f0/mod/forum/db/upgrade.php#L338" ruleset="Squiz" rule="WhiteSpace.ControlStructureSpacing.SpacingAfterOpen" url="https://moodledev.io/general/development/policies/codingstyle" type="error" weight="5">
#           <message>Blank line found at start of control structure</message>
#           <description/>
#           <code/>
#         </problem>
#       </mess>
#     </check>
```


Test 9 (`local_ci_fixture_upgrade_external_backup_skipped_for_plugins`) of `remote_branch_checker` now has one additional error in the phpcs check because of the `RSR12` rulseset (`rule="Classes.OpeningBraceSpace.Found"`)

```
[...]

#       <detail name="phpcs" status="error" numerrors="3" numwarnings="1"/>

[...]

#     <check id="phpcs" title="PHP coding style problems" url="https://moodledev.io/general/development/policies/codingstyle" numerrors="3" numwarnings="1" allowfiltering="1">
#       <description>This section shows the coding style problems detected in the code by phpcs</description>
#       <mess>
#         <problem file="mod/glossary/tests/lib_test.php" linefrom="17" lineto="17" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/737b1bd19c9b979ec9d146f91c559c0fa7df5899/mod/glossary/tests/lib_test.php#L17" ruleset="moodle" rule="PHPUnit.TestCaseNames.UnexpectedNS" url="https://moodledev.io/general/development/policies/codingstyle" type="error" weight="5">
#           <message>PHPUnit class namespace "mod_wrong" does not match expected file namespace "mod_glossary"</message>
#           <description/>
#           <code/>
#         </problem>
#         <problem file="mod/glossary/tests/lib_test.php" linefrom="40" lineto="40" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/737b1bd19c9b979ec9d146f91c559c0fa7df5899/mod/glossary/tests/lib_test.php#L40" ruleset="moodle" rule="PHPUnit.TestCaseNames.NoMatch" url="https://moodledev.io/general/development/policies/codingstyle" type="warning" weight="1">
#           <message>PHPUnit testcase name "mod_glossary_lib_testcase_also_wrong" does not match file name "lib_test"</message>
#           <description/>
#           <code/>
#         </problem>
#         <problem file="mod/glossary/tests/lib_test.php" linefrom="40" lineto="40" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/737b1bd19c9b979ec9d146f91c559c0fa7df5899/mod/glossary/tests/lib_test.php#L40" ruleset="moodle" rule="PHPUnit.TestCaseNames.Irregular" url="https://moodledev.io/general/development/policies/codingstyle" type="error" weight="5">
#           <message>PHPUnit irregular testcase name found: mod_glossary_lib_testcase_also_wrong (_test/_testcase ended expected)</message>
#           <description/>
#           <code/>
#         </problem>
#         <problem file="mod/glossary/tests/lib_test.php" linefrom="40" lineto="40" method="" class="" package="" api="" diffurl="https://git.in.moodle.com/integration/prechecker/blob/737b1bd19c9b979ec9d146f91c559c0fa7df5899/mod/glossary/tests/lib_test.php#L40" ruleset="PSR12" rule="Classes.OpeningBraceSpace.Found" url="https://moodledev.io/general/development/policies/codingstyle" type="error" weight="5">
#           <message>Opening brace must not be followed by a blank line</message>
#           <description/>
#           <code/>
#         </problem>
#       </mess>
#     </check>
```

[MDLSITE-7597]: https://moodle.atlassian.net/browse/MDLSITE-7597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ