### PR TITLE
Handle update_test_results_customfield flag

### DIFF
--- a/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/postissue.sh
+++ b/tracker_automations/bulk_prelaunch_jobs/criteria/list_of_mdls/postissue.sh
@@ -1,5 +1,12 @@
+if [[ ! -z "${update_test_results_customfield}" ]]; then
 # Update the automated testing field with the results.
-${basereq} --action setFieldValue \
-    --issue ${issue} \
-    --field "Automated test results" \
-    --file "${resultfile}.${issue}.txt"
+    ${basereq} --action setFieldValue \
+        --issue ${issue} \
+        --field "Automated test results" \
+        --file "${resultfile}.${issue}.txt"
+else
+    # Just add the results as a comment.
+    ${basereq} --action addComment \
+        --issue ${issue} \
+        --file "${resultfile}.${issue}.txt"
+fi


### PR DESCRIPTION
This commit handles a new flag added to the list_of_mdls (ToBiC) job: post_results_in_customfield

If that post_results_in_customfield setting is checked, the results will be posted to the "Automated test results" field, if not, it will post as a comment.