### PR TITLE
Allow `true` return annotation in `upgrade.php` function

### DIFF
--- a/check_upgrade_savepoints/check_upgrade_savepoints.php
+++ b/check_upgrade_savepoints/check_upgrade_savepoints.php
@@ -60,7 +60,7 @@ foreach ($files as $file) {
 
     $contents = file_get_contents($file);
 
-    $function_regexp = '\s*function\s+xmldb_[a-zA-Z0-9_]+?_upgrade\s*\(.*?version.*?\)(?::\sbool)?\s*(?=\{)';
+    $function_regexp = '\s*function\s+xmldb_[a-zA-Z0-9_]+?_upgrade\s*\(.*?version.*?\)(?:\s*:\s*(?:bool|true))?\s*(?=\{)';
     $return_regexp = '\s*return true;';
     $anyfunction_regexp = '\s*function\s*[a-z0-9_]+?\s*\(.*?\)\s*{'; // MDL-34103
 


### PR DESCRIPTION
Technically, the `xmldb_..._upgrade` function in `db/upgrade.php` always returns `true`. [Since PHP 8.2](https://www.php.net/releases/8.2/en.php#null_false_true_types) you can actually annotate it accordingly. I discovered that doing so causes this weird warning from the `savepoints` checker:

```
    + WARN: Detected fewer 'if' blocks (0) than 'savepoint' calls (1). Repeated savepoints?
    + NOTE: cannot find 'if' blocks within the upgrade function
```

This PR just extends the function RegEx to also match a `true` return type annotation, not just one with `bool`. (Also being more lenient with the whitespace here would not hurt since this is not a style checker.)

It seems [`tests/check_upgrade_savepoints.bats`](https://github.com/moodlehq/moodle-local_ci/blob/e02ac823f33403572166d343e27da6803ba0dbbe/tests/check_upgrade_savepoints.bats) does the testing and there already is the [`tests/fixtures/check_upgrade_savepoints/returning_bool.patch`](https://github.com/moodlehq/moodle-local_ci/blob/e02ac823f33403572166d343e27da6803ba0dbbe/tests/fixtures/check_upgrade_savepoints/returning_bool.patch) fixture for `bool` return types. But I have never seen this type of testing setup before, so I am not sure how best to add a corresponding test case.

If you tell me how I should go about it, I am sure adding a test case for this should not be too difficult.